### PR TITLE
fix: accept folder.view2 exports in Import Everything

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folderview3.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folderview3.js
@@ -141,6 +141,31 @@ const downloadDocker = async (id) => {
     }
 };
 
+// A folder export is either one folder object or an id => folder map (both shapes are what
+// folder.view2 downloads). Neither carries a docker|vm marker — the caller supplies the type.
+const fv3IsFolderShaped = (o) => !!o && typeof o === 'object' && !Array.isArray(o)
+    && typeof o.name === 'string'
+    && (Array.isArray(o.containers) || (!!o.settings && typeof o.settings === 'object'));
+
+const fv3CountFolderExport = (parsed) => {
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return 0;
+    if (fv3IsFolderShaped(parsed)) return 1;
+    const folders = Object.values(parsed);
+    return (folders.length && folders.every(fv3IsFolderShaped)) ? folders.length : 0;
+};
+
+const fv3ImportFolderMap = async (content, type) => {
+    if (content.name) {
+        await $.post('/plugins/folder.view3/server/create.php', { type: type, content: JSON.stringify(content) });
+    } else {
+        for (const [id, folder] of Object.entries(content)) {
+            await $.post('/plugins/folder.view3/server/update.php', { type: type, content: JSON.stringify(folder), id: id });
+        }
+        if (type === 'docker') await $.post('/plugins/folder.view3/server/sync_order.php', { type: 'docker' });
+    }
+    populateTable();
+};
+
 const importDocker = () => {
     let input = document.getElementById('fv3-import-docker-file');
     input.onchange = (e) => {
@@ -169,15 +194,7 @@ const importDocker = () => {
                 swal({ title: 'Wrong import', text: 'This is a full backup bundle — use "Import Everything" to restore it, or select a Docker folders export here.', type: 'error' });
                 return;
             }
-            if(content.name) {
-                await $.post('/plugins/folder.view3/server/create.php', { type: 'docker', content: JSON.stringify(content) });
-            } else {
-                for (const [id, folder] of Object.entries(content)) {
-                    await $.post('/plugins/folder.view3/server/update.php', { type: 'docker', content: JSON.stringify(folder), id: id });
-                }
-                await $.post('/plugins/folder.view3/server/sync_order.php', { type: 'docker' });
-            }
-            populateTable();
+            await fv3ImportFolderMap(content, 'docker');
         }
     }
     input.click();
@@ -211,14 +228,7 @@ const importVm = () => {
                 swal({ title: 'Wrong import', text: 'This is a full backup bundle — use "Import Everything" to restore it, or select a VM folders export here.', type: 'error' });
                 return;
             }
-            if(content.name) {
-                await $.post('/plugins/folder.view3/server/create.php', { type: 'vm', content: JSON.stringify(content) });
-            } else {
-                for (const [id, folder] of Object.entries(content)) {
-                    await $.post('/plugins/folder.view3/server/update.php', { type: 'vm', content: JSON.stringify(folder), id: id });
-                }
-            }
-            populateTable();
+            await fv3ImportFolderMap(content, 'vm');
         }
     }
     input.click();
@@ -595,6 +605,15 @@ const fv3ExportAll = async () => {
 };
 window.fv3ExportAll = fv3ExportAll;
 
+const fv3ImportFolderExport = async (content, type) => {
+    swal.close();
+    try {
+        await fv3ImportFolderMap(content, type);
+    } catch (err) {
+        swal({ title: 'Error', text: 'Import failed.', type: 'error' });
+    }
+};
+
 $('#fv3-import-all-btn').on('click', () => $('#fv3-import-all').click());
 $('#fv3-import-all').on('change', function() {
     const file = this.files[0];
@@ -604,7 +623,30 @@ $('#fv3-import-all').on('change', function() {
     reader.onload = async (e) => {
         try {
             const parsed = JSON.parse(e.target.result);
-            if (!parsed.fv3_export_version) { swal({ title: 'Error', text: 'Not a valid FV3 backup file.', type: 'error' }); return; }
+            if (!parsed.fv3_export_version) {
+                // folder.view2 exports land here — take them rather than dead-ending the user.
+                const count = fv3CountFolderExport(parsed);
+                if (!count) { swal({ title: 'Error', text: 'Not a valid FV3 backup file.', type: 'error' }); return; }
+                // The choice can't ride on the confirm/cancel boolean: swal reports ESC and Cancel
+                // identically, so a dismissal would silently import as whichever type lost the coin toss.
+                swal({
+                    title: 'Folder export detected',
+                    text: `<p>This file holds ${count} folder${count === 1 ? '' : 's'} — a FolderView2 or per-type export, not a full FV3 backup.</p>`
+                        + '<p>Import as:</p><p>'
+                        + '<button class="fv3-choice" style="margin:0 4px" data-fv3-type="docker">Docker folders</button>'
+                        + '<button class="fv3-choice" style="margin:0 4px" data-fv3-type="vm">VM folders</button></p>',
+                    html: true,
+                    showConfirmButton: false,
+                    showCancelButton: true,
+                    cancelButtonText: 'Cancel'
+                });
+                // An inline onclick inside swal's own markup never fires — bind explicitly instead.
+                // The buttons exist synchronously once swal() has returned.
+                document.querySelectorAll('.sweet-alert button.fv3-choice').forEach(b => {
+                    b.addEventListener('click', () => fv3ImportFolderExport(parsed, b.dataset.fv3Type));
+                });
+                return;
+            }
             const items = [];
             if (parsed.docker && Object.keys(parsed.docker).length) items.push(Object.keys(parsed.docker).length + ' Docker folders');
             if (parsed.vm && Object.keys(parsed.vm).length) items.push(Object.keys(parsed.vm).length + ' VM folders');

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folderview3.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folderview3.js
@@ -155,7 +155,9 @@ const fv3CountFolderExport = (parsed) => {
 };
 
 const fv3ImportFolderMap = async (content, type) => {
-    if (content.name) {
+    // Structural test, not `content.name` — an empty name is legal and would otherwise route a
+    // single folder down the map path, writing its own keys (name, icon, settings…) as folder ids.
+    if (fv3IsFolderShaped(content)) {
         await $.post('/plugins/folder.view3/server/create.php', { type: type, content: JSON.stringify(content) });
     } else {
         for (const [id, folder] of Object.entries(content)) {


### PR DESCRIPTION
## Problem

A folder.view2 user reported their backup JSON could not be imported into FolderView3 and that they had to convert it by hand.

The file was always importable — **Import Docker** / **Import VM** accept a bare folder.view2 export verbatim. **Import Everything** rejected it, because `importAll` requires an `fv3_export_version` wrapper and folder.view2 has no such concept: it downloads `Docker.json` / `VM.json`, a bare `id => folder` map, or a single folder object.

The guard was one-directional. `importDocker`/`importVm` already detect a full bundle and redirect to Import Everything, but nothing pointed the other way — the error read `Not a valid FV3 backup file.`, which reads as "your file is broken" and sends people off to convert a file that never needed converting.

## Change

Import Everything now detects a bare folder export and offers **Docker folders** / **VM folders**, reusing the same import path as the dedicated buttons.

Two details worth calling out:

- **The type choice is buttons, not confirm/cancel.** sweetalert reports ESC and Cancel identically (`doneFunction(!1)`), so mapping the two types onto that boolean would silently import as whichever type mapped to `false` whenever the dialog was dismissed.
- **The buttons are bound with `addEventListener`.** An inline `onclick` inside sweetalert's own markup compiles but never fires — the modal swallows the click, so the dialog would appear and do nothing.

`fv3ImportFolderMap()` is extracted so the docker, vm and folder-export paths share one loop instead of three copies. Behaviour is unchanged, including vm import not calling `sync_order`.

## Detection

A payload counts as a folder export only when it is a single folder object, or a non-empty map whose every value is folder-shaped (`name` string, plus a `containers` array or `settings` object). Anything else still gets `Not a valid FV3 backup file.` Verified against `{}`, arrays, `css-config.json`, `settings.json`, and maps containing a non-folder member.

## Testing

Verified on Unraid 7.3.2 against plugin 2026.08.01, driving a real `File` through the real file input:

- folder.view2 map (2 folders) -> modal reports "2 folders" -> **Docker folders** -> both present in `docker.json`, original ids and regex intact
- single-folder export -> modal reports "1 folder" (singular)
- folder.view2 map -> **VM folders** -> written to `vm.json`, `docker.json` untouched
- negative cases rejected as before
- ESC / Cancel writes nothing

Imported folders keep their folder.view2 ids, so members and settings carry over unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing folder exports from full backups.
  * Users can choose whether valid exports are imported as Docker or VM folders.
  * Import results now show the number of folders detected.
  * Imported folders are automatically added, ordered, and displayed in the refreshed table.
  * Supports both single-folder and multi-folder exports.

* **Bug Fixes**
  * Invalid or unsupported export files continue to be rejected with an error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->