### PR TITLE
fix: match autostart membership to what the UI renders

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -314,22 +314,48 @@
             return;
         }
 
+        // `folder.view3: <name>` label claims, keyed by container name. getDockerContainers()
+        // carries no Labels, so read them from the same raw endpoint readInfo() uses.
+        $ctLabels = [];
+        $rawCts = $dockerClient->getDockerJSON("/containers/json?all=1");
+        if (is_array($rawCts)) {
+            foreach ($rawCts as $rc) {
+                $rcName = ltrim($rc['Names'][0] ?? '', '/');
+                $rcLabel = $rc['Labels']['folder.view3'] ?? '';
+                if ($rcName !== '' && $rcLabel !== '') { $ctLabels[$rcName] = $rcLabel; }
+            }
+        }
+        $folderNameSet = [];
+        foreach ($folders as $folder) {
+            if (isset($folder['name'])) { $folderNameSet[$folder['name']] = true; }
+        }
+
         $folderContainers = [];
         $folderNames = [];
         $assignedContainers = [];
-        // Explicit members of any folder beat regex matches elsewhere (issue #46)
+        // Explicit members and label claims of any folder beat regex matches elsewhere (issue #46)
         $explicitAssigned = [];
         foreach ($folders as $folder) {
             $explicitAssigned = array_merge($explicitAssigned, $folder['containers'] ?? []);
         }
+        foreach ($ctLabels as $ctName => $ctLabel) {
+            if (isset($folderNameSet[$ctLabel])) { $explicitAssigned[] = $ctName; }
+        }
         foreach ($folders as $folderId => $folder) {
             $members = $folder['containers'] ?? [];
-            if (!empty($folder['regex'])) {
+            // trim(), not empty(): empty("0") is true in PHP, so a regex of "0" was silently
+            // dropped here while docker.js applied it — autostart then disagreed with the screen.
+            if (isset($folder['regex']) && trim($folder['regex']) !== '') {
                 $regex = '/' . str_replace('/', '\/', $folder['regex']) . '/';
                 foreach ($allContainerNames as $name) {
                     if (@preg_match($regex, $name) && !in_array($name, $members) && !in_array($name, $explicitAssigned)) {
                         $members[] = $name;
                     }
+                }
+            }
+            foreach ($ctLabels as $ctName => $ctLabel) {
+                if ($ctLabel === ($folder['name'] ?? null) && !in_array($ctName, $members)) {
+                    $members[] = $ctName;
                 }
             }
             $members = array_values(array_filter($members, function($m) use ($allContainerNames, $assignedContainers) {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -318,12 +318,21 @@
         // carries no Labels, so read them from the same raw endpoint readInfo() uses.
         $ctLabels = [];
         $rawCts = $dockerClient->getDockerJSON("/containers/json?all=1");
-        if (is_array($rawCts)) {
-            foreach ($rawCts as $rc) {
-                $rcName = ltrim($rc['Names'][0] ?? '', '/');
-                $rcLabel = $rc['Labels']['folder.view3'] ?? '';
-                if ($rcName !== '' && $rcLabel !== '') { $ctLabels[$rcName] = $rcLabel; }
+        // Fail closed. A failed or partial read yields no label claims, and the order below would
+        // then write label-assigned containers back out as unassigned — the same hazard $ctListComplete
+        // guards against above, so abort rather than fall through to the permissive path.
+        if (!is_array($rawCts) || count($rawCts) < count($allContainerNames)) {
+            fv3_debug_log("syncContainerOrder: label read unavailable or incomplete, aborting before write");
+            return;
+        }
+        foreach ($rawCts as $rc) {
+            $rcName = is_array($rc) ? ltrim($rc['Names'][0] ?? '', '/') : '';
+            if ($rcName === '') {
+                fv3_debug_log("syncContainerOrder: unnamed container in label read, aborting before write");
+                return;
             }
+            $rcLabel = $rc['Labels']['folder.view3'] ?? '';
+            if (is_string($rcLabel) && $rcLabel !== '') { $ctLabels[$rcName] = $rcLabel; }
         }
         $folderNameSet = [];
         foreach ($folders as $folder) {
@@ -343,9 +352,10 @@
         }
         foreach ($folders as $folderId => $folder) {
             $members = $folder['containers'] ?? [];
-            // trim(), not empty(): empty("0") is true in PHP, so a regex of "0" was silently
-            // dropped here while docker.js applied it — autostart then disagreed with the screen.
-            if (isset($folder['regex']) && trim($folder['regex']) !== '') {
+            // is_string + trim, not empty(): empty("0") is true in PHP, so a regex of "0" was
+            // silently dropped while docker.js applied it. The type check mirrors docker.js and
+            // keeps a non-string regex from fataling trim() (TypeError on PHP 8).
+            if (is_string($folder['regex'] ?? null) && trim($folder['regex']) !== '') {
                 $regex = '/' . str_replace('/', '\/', $folder['regex']) . '/';
                 foreach ($allContainerNames as $name) {
                     if (@preg_match($regex, $name) && !in_array($name, $members) && !in_array($name, $explicitAssigned)) {


### PR DESCRIPTION
## Problem

`syncContainerOrder()` decides folder membership differently from `docker.js`, so the autostart file can disagree with what the Docker tab renders.

**Docker labels were missing entirely.** `docker.js:305` assigns a container to a folder when its `folder.view3` label matches the folder name, and `docker.js:35` treats that claim as beating another folder's regex. The PHP had no label handling at all — no reference to the label anywhere under `server/`. A container assigned to a folder purely by label therefore renders inside that folder on screen but is invisible to the autostart calculation, and gets ordered as an unassigned container instead of with its group.

The labels were not simply overlooked: `getDockerContainers()` returns no `Labels` key (verified across all 45 containers on a live server), so they were not reachable from the data source this function already had.

**The regex gate diverged in both directions:**

| folder regex | `docker.js` | `syncContainerOrder` (before) |
|---|---|---|
| `0` | applies it | skips — `empty("0")` is `true` in PHP |
| `"   "` | skips via `.trim()` | applies `/   /` |

## Change

- Read `folder.view3` label claims from `getDockerJSON("/containers/json?all=1")` — the same endpoint `readInfo()` already uses — and assign them to the matching folder, with claims joining `$explicitAssigned` so precedence matches the client (explicit > label > regex).
- Gate the regex on `trim($folder['regex']) !== ''` to mirror the JS test exactly, fixing both directions.

Cost is one extra Docker API call per sync, measured at 5ms. If that call fails the label map is empty and behaviour falls back to exactly what it is today.

## Testing

On Unraid 7.3.2 with plugin 2026.08.01, calling `syncContainerOrder("docker")` directly against a live 45-container, 10-folder config:

**No change for configs using neither labels nor regex** — the function ran (returned in 199ms, autostart file mtime advanced, confirming it really executed and rewrote) and produced a byte-identical file.

**Label membership now honoured.** A container labelled `folder.view3=Utilities`, seeded into the autostart file, with everything else held constant:

| | position |
|---|---|
| before | line 1 — prepended as an unrecognised container |
| after | line 32 — directly after that folder's block (its members occupy lines 27-31) |

## Note for reviewers

Membership is now computed in two places — `docker.js` and `lib.php` — and nothing enforces that they agree. This PR makes them agree; it does not stop them drifting again, which is how the label gap arose. A single source of truth (the server exposing computed membership, or the client consuming it) would be the durable fix and is deliberately out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker containers can now be assigned to matching folders using `folder.view3` labels.
  * Explicit folder assignments take priority over pattern-based matching.

* **Bug Fixes**
  * Fixed valid regular-expression patterns such as `"0"` being incorrectly treated as empty.
  * Improved handling of invalid or incomplete container labels to prevent unintended folder changes.
  * Containers with unnamed folder labels are no longer assigned automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->