### PR TITLE
fix: strip phantom folder-* sort-prefs entries on uninstall

### DIFF
--- a/folder.view3.plg
+++ b/folder.view3.plg
@@ -725,7 +725,7 @@ After updating, hard-refresh your browser (Ctrl/Cmd+Shift+R) and clear its cache
                 [ -f "$f" ] || continue
                 # RT (gawk, guaranteed on Unraid) keeps each line terminator as-is,
                 # incl. a missing final newline.
-                if awk -F'"' 'BEGIN{n=0} $0 ~ /^[0-9]+="[^"]*"$/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) if (v ~ /[A-Z]/) if (v ~ /[a-z]/) next; printf "%d=\"%s\"%s", n, v, RT; n++; next } { printf "%s%s", $0, RT }' "$f" > "$f.fv3clean"; then
+                if awk -F'"' 'BEGIN{RS="\r\n|\n|\r"; n=0} $0 ~ /^[0-9]+="[^"]*"$/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) if (v ~ /[A-Z]/) if (v ~ /[a-z]/) next; printf "%d=\"%s\"%s", n, v, RT; n++; next } { printf "%s%s", $0, RT }' "$f" > "$f.fv3clean"; then
                     mv "$f.fv3clean" "$f"
                 else
                     rm -f "$f.fv3clean"

--- a/folder.view3.plg
+++ b/folder.view3.plg
@@ -719,6 +719,16 @@ After updating, hard-refresh your browser (Ctrl/Cmd+Shift+R) and clear its cache
             done
             rm -rf &plugdir;
             rm -rf /boot/config/plugins/&name;
+            # Folder rows persist phantom 'folder-ID' entries into the stock
+            # sort prefs via UserPrefs.php — strip them and renumber on the way out.
+            for f in /boot/config/plugins/dockerMan/userprefs.cfg /boot/config/plugins/dynamix.vm.manager/userprefs.cfg; do
+                [ -f "$f" ] || continue
+                if awk -F'"' 'BEGIN{n=0} $0 ~ /^[0-9]+="/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) next; print n"=\""v"\""; n++; next } { print }' "$f" > "$f.fv3clean"; then
+                    mv "$f.fv3clean" "$f"
+                else
+                    rm -f "$f.fv3clean"
+                fi
+            done
         </INLINE>
     </FILE>
 

--- a/folder.view3.plg
+++ b/folder.view3.plg
@@ -723,7 +723,9 @@ After updating, hard-refresh your browser (Ctrl/Cmd+Shift+R) and clear its cache
             # sort prefs via UserPrefs.php — strip them and renumber on the way out.
             for f in /boot/config/plugins/dockerMan/userprefs.cfg /boot/config/plugins/dynamix.vm.manager/userprefs.cfg; do
                 [ -f "$f" ] || continue
-                if awk -F'"' 'BEGIN{n=0} $0 ~ /^[0-9]+="[^"]*"$/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) if (v ~ /[A-Z]/) if (v ~ /[a-z]/) next; print n"=\""v"\""; n++; next } { print }' "$f" > "$f.fv3clean"; then
+                # RT (gawk, guaranteed on Unraid) keeps each line terminator as-is,
+                # incl. a missing final newline.
+                if awk -F'"' 'BEGIN{n=0} $0 ~ /^[0-9]+="[^"]*"$/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) if (v ~ /[A-Z]/) if (v ~ /[a-z]/) next; printf "%d=\"%s\"%s", n, v, RT; n++; next } { printf "%s%s", $0, RT }' "$f" > "$f.fv3clean"; then
                     mv "$f.fv3clean" "$f"
                 else
                     rm -f "$f.fv3clean"

--- a/folder.view3.plg
+++ b/folder.view3.plg
@@ -16,6 +16,9 @@
 
 After updating, hard-refresh your browser (Ctrl/Cmd+Shift+R) and clear its cache if the page doesn't display correctly — before submitting a debug .json.
 
+###2026.08.26.1
+- Uninstalling now also removes the plugin's leftover entries from the Docker/VM sort-order preferences, including entries left behind by folder.view and folder.view2
+
 ###2026.08.14
 - Uninstalling now removes the plugin cleanly after previous version improvements
 - Import Everything now accepts a folder.view2 backup file instead of rejecting it as invalid

--- a/folder.view3.plg
+++ b/folder.view3.plg
@@ -723,7 +723,7 @@ After updating, hard-refresh your browser (Ctrl/Cmd+Shift+R) and clear its cache
             # sort prefs via UserPrefs.php — strip them and renumber on the way out.
             for f in /boot/config/plugins/dockerMan/userprefs.cfg /boot/config/plugins/dynamix.vm.manager/userprefs.cfg; do
                 [ -f "$f" ] || continue
-                if awk -F'"' 'BEGIN{n=0} $0 ~ /^[0-9]+="/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) next; print n"=\""v"\""; n++; next } { print }' "$f" > "$f.fv3clean"; then
+                if awk -F'"' 'BEGIN{n=0} $0 ~ /^[0-9]+="[^"]*"$/ { v=$2; if (v ~ /^folder-[A-Za-z0-9]+$/) if (length(v) >= 20) if (v ~ /[A-Z]/) if (v ~ /[a-z]/) next; print n"=\""v"\""; n++; next } { print }' "$f" > "$f.fv3clean"; then
                     mv "$f.fv3clean" "$f"
                 else
                     rm -f "$f.fv3clean"


### PR DESCRIPTION
## What

Uninstalling the plugin now strips the phantom `folder-<id>` entries it left in the stock sort preferences (`/boot/config/plugins/dockerMan/userprefs.cfg` and `/boot/config/plugins/dynamix.vm.manager/userprefs.cfg`) and renumbers the remaining entries.

## Why

Folder rows carry a hidden `appname` of `folder-<id>` and sit in the stock sortable list, so Unraid's own reorder handler serializes them into `userprefs.cfg` via the intercepted `UserPrefs.php` save. That file belongs to dockerMan, not to this plugin, so the entries survive uninstall and sit there indefinitely unless the user happens to reorder again on the stock page.

The entries are harmless to the stock Docker/VM pages today (7.2.8 and 7.3.2 iterate containers and look each one up in prefs, so extra entries are never read), but they are invisible residue: they don't show up in any plugin folder, they confuse support investigations after an uninstall, and they only stay harmless for as long as every consumer of that file stays tolerant. folder.view and folder.view2 used the same mechanism, so the sweep also clears entries left behind by those, which no longer ship a fix.

## How

- Matches values of `folder-` followed by 13+ alphanumerics (total length ≥ 20) containing at least one uppercase and one lowercase letter. Generated ids are 16–27 chars of stripped base64 and mixed-case in all but ~0.004% of cases; human container names that start with `folder-` are shorter, contain separators, or are single-case (e.g. `folder-examplecontainer`), so they are kept.
- Only complete `N="value"` records are rewritten; unterminated or trailing-content lines and anything else malformed pass through byte-for-byte. Surviving entries are renumbered from 0 to keep the file in the shape dockerMan writes.
- The rewrite lands in a same-directory temp file and only replaces the original if awk exits cleanly, so a failed read can't clobber the prefs. Missing files are skipped.
- Runs last in the remove block, after the package and config removal.

Sort positions are intentionally not preserved across an uninstall/reinstall — folder definitions live in the plugin config backup, and the stock page regenerates sort order on the next reorder.

## Testing

- awk pass verified against a copy of a real 56-entry `userprefs.cfg` containing 12 phantom entries (ids 19–27 chars): all phantoms removed, renumbering sequential, `folder-abc` / `folder-mediaserver` / `folder-examplecontainer` style names kept, blank lines and malformed records (unterminated quote, trailing content) untouched byte-for-byte, output idempotent on re-run.
- Full remove-block loop exercised against docker + VM fixtures plus a missing-file path: both files rewritten, no temp files left behind.
- Records split on any line ending (gawk regex `RS`), so a prefs file hand-edited over SMB with CRLF endings still gets cleaned rather than silently skipped.
- Line terminators preserved exactly (gawk `RT`): fixtures for a trailing-newline file, a malformed unterminated tail, a valid unterminated tail, and CRLF/mixed-ending files verified by byte dump on a live Unraid 7.3.2 box (host awk is GNU Awk 5.4.0).
- `xmllint --noout` and the manifest validator pass on the edited `.plg`.
- Not yet exercised on a live box; the remove block change is inert until an actual uninstall.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall cleanup when processing preference entries with different line-ending formats.
  * Preserves existing line endings and files without a final newline while filtering and renumbering entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->