### PR TITLE
feat: persist folder order and self-heal sort prefs after reinstall

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -95,10 +95,15 @@ reviews:
         parent; a handler attached once to a node that later gets replaced is
         the bug.
 
-        CSRF: every state-changing request (POST/PUT/DELETE via fetch/$.ajax)
-        must carry the CSRF token (csrf_token field / X-Csrf-Token header). A
-        new mutating call that omits it will be rejected by Unraid's
-        local_prepend.php — flag it.
+        CSRF: Unraid's webGui auto-attaches csrf_token to every same-origin
+        jQuery POST (global ajaxPrefilter in HeadInlineJS.php; upstream
+        guidance: "the webGUI will add it to POST methods automatically"), so
+        a bare same-origin $.post/$.ajax POST is correct — do NOT flag it.
+        Only requests the injector can't reach need the token explicitly
+        (csrf_token field or X-Csrf-Token header, guarded with
+        typeof csrf_token !== 'undefined'): fetch/XMLHttpRequest, and any
+        non-POST or cross-origin mutating call. Flag a mutating fetch/XHR
+        without it.
 
         EVENT BUS FROZEN: the customEvents / event-bus contract is FROZEN. Do
         not rename, repurpose, or remove existing custom events — extensions

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -1373,7 +1373,8 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         fv3Debug('ajaxPrefilter', 'modified data', options.data);
         // Snapshot the interleaved order into FV3's own config so a reinstall can
         // restore folder positions after the uninstall prefs cleanup (server-side heal)
-        $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: data.get('names'), csrf_token: typeof csrf_token !== 'undefined' ? csrf_token : ''});
+        // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php)
+        $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: data.get('names')});
     }
 });
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -1371,6 +1371,9 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         data.set('index', num);
         options.data = data.toString();
         fv3Debug('ajaxPrefilter', 'modified data', options.data);
+        // Snapshot the interleaved order into FV3's own config so a reinstall can
+        // restore folder positions after the uninstall prefs cleanup (server-side heal)
+        $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: data.get('names')});
     }
 });
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -1373,7 +1373,7 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         fv3Debug('ajaxPrefilter', 'modified data', options.data);
         // Snapshot the interleaved order into FV3's own config so a reinstall can
         // restore folder positions after the uninstall prefs cleanup (server-side heal)
-        $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: data.get('names')});
+        $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: data.get('names'), csrf_token: typeof csrf_token !== 'undefined' ? csrf_token : ''});
     }
 });
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -1354,6 +1354,7 @@ $(document).on('change', '.advancedview', function () {
 const createFolderBtn = () => fv3CreateFolderBtn('docker', '/Docker/Folder');
 
 // Intercept Unraid's UserPrefs request to rewrite folder/order numbers — required for autostart and draw order.
+let fv3OrderSnapshotChain = Promise.resolve();
 $.ajaxPrefilter((options, originalOptions, jqXHR) => {
     if (options.url === "/plugins/dynamix.docker.manager/include/UserPrefs.php") {
         fv3Debug('ajaxPrefilter', 'UserPrefs intercepted', {...options});
@@ -1372,9 +1373,13 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         options.data = data.toString();
         fv3Debug('ajaxPrefilter', 'modified data', options.data);
         // Snapshot the interleaved order into FV3's own config so a reinstall can
-        // restore folder positions after the uninstall prefs cleanup (server-side heal)
-        // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php)
-        $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: data.get('names')});
+        // restore folder positions after the uninstall prefs cleanup (server-side heal).
+        // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php).
+        // Chained so a delayed earlier snapshot can't land after (and overwrite) a newer one.
+        const fv3SnapshotNames = data.get('names');
+        fv3OrderSnapshotChain = fv3OrderSnapshotChain.then(() =>
+            $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: fv3SnapshotNames})
+        ).catch(() => {});
     }
 });
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -1385,7 +1385,10 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
             fv3SnapshotGen === fv3OrderSnapshotGen
                 ? $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: fv3SnapshotNames})
                 : undefined
-        ).catch(() => {});
+        ).catch(() => {
+            // Reorder itself already saved via stock UserPrefs — only the durability copy failed
+            console.warn('[FV3] Docker order snapshot save failed; layout restore after a reinstall may use an older order.');
+        });
     }
 });
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -1355,12 +1355,15 @@ const createFolderBtn = () => fv3CreateFolderBtn('docker', '/Docker/Folder');
 
 // Intercept Unraid's UserPrefs request to rewrite folder/order numbers — required for autostart and draw order.
 let fv3OrderSnapshotChain = Promise.resolve();
+let fv3OrderSnapshotGen = 0;
 $.ajaxPrefilter((options, originalOptions, jqXHR) => {
     if (options.url === "/plugins/dynamix.docker.manager/include/UserPrefs.php") {
         fv3Debug('ajaxPrefilter', 'UserPrefs intercepted', {...options});
         const data = new URLSearchParams(options.data);
         if (!data.has('names')) {
-            // Reset Order POST has only {reset:true} — nothing to renumber, let it through.
+            // Reset Order POST has only {reset:true} — nothing to renumber, let it through,
+            // and invalidate queued snapshot posts so a stale pre-reset order can't be saved.
+            fv3OrderSnapshotGen++;
             fv3Debug('ajaxPrefilter', 'no names param, passing through');
             return;
         }
@@ -1377,8 +1380,11 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php).
         // Chained so a delayed earlier snapshot can't land after (and overwrite) a newer one.
         const fv3SnapshotNames = data.get('names');
+        const fv3SnapshotGen = fv3OrderSnapshotGen;
         fv3OrderSnapshotChain = fv3OrderSnapshotChain.then(() =>
-            $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: fv3SnapshotNames})
+            fv3SnapshotGen === fv3OrderSnapshotGen
+                ? $.post('/plugins/folder.view3/server/update_order.php', {type: 'docker', names: fv3SnapshotNames})
+                : undefined
         ).catch(() => {});
     }
 });

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -811,7 +811,10 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
             fv3SnapshotGen === fv3OrderSnapshotGen
                 ? $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: fv3SnapshotNames})
                 : undefined
-        ).catch(() => {});
+        ).catch(() => {
+            // Reorder itself already saved via stock UserPrefs — only the durability copy failed
+            console.warn('[FV3] VM order snapshot save failed; layout restore after a reinstall may use an older order.');
+        });
         $('.unhide').show();
     } else if (options.url === "/plugins/dynamix.vm.manager/include/VMMachines.php" && !loadedFolder) {
         jqXHR.promise().then(async () => {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -799,7 +799,7 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         options.data = data.toString();
         // Snapshot the interleaved order into FV3's own config so a reinstall can
         // restore folder positions after the uninstall prefs cleanup (server-side heal)
-        $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: data.get('names')});
+        $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: data.get('names'), csrf_token: typeof csrf_token !== 'undefined' ? csrf_token : ''});
         $('.unhide').show();
     } else if (options.url === "/plugins/dynamix.vm.manager/include/VMMachines.php" && !loadedFolder) {
         jqXHR.promise().then(async () => {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -780,6 +780,7 @@ const createFolderBtn = () => fv3CreateFolderBtn('vm', '/VMs/Folder');
 
 
 // Intercept Unraid's UserPrefs request to rewrite folder/order numbers — required for autostart and draw order.
+let fv3OrderSnapshotChain = Promise.resolve();
 $.ajaxPrefilter((options, originalOptions, jqXHR) => {
     if (options.url === "/plugins/dynamix.vm.manager/include/UserPrefs.php") {
         const data = new URLSearchParams(options.data);
@@ -798,9 +799,13 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         data.set('index', num);
         options.data = data.toString();
         // Snapshot the interleaved order into FV3's own config so a reinstall can
-        // restore folder positions after the uninstall prefs cleanup (server-side heal)
-        // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php)
-        $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: data.get('names')});
+        // restore folder positions after the uninstall prefs cleanup (server-side heal).
+        // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php).
+        // Chained so a delayed earlier snapshot can't land after (and overwrite) a newer one.
+        const fv3SnapshotNames = data.get('names');
+        fv3OrderSnapshotChain = fv3OrderSnapshotChain.then(() =>
+            $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: fv3SnapshotNames})
+        ).catch(() => {});
         $('.unhide').show();
     } else if (options.url === "/plugins/dynamix.vm.manager/include/VMMachines.php" && !loadedFolder) {
         jqXHR.promise().then(async () => {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -797,6 +797,9 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         data.set('names', containers.join(';'));
         data.set('index', num);
         options.data = data.toString();
+        // Snapshot the interleaved order into FV3's own config so a reinstall can
+        // restore folder positions after the uninstall prefs cleanup (server-side heal)
+        $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: data.get('names')});
         $('.unhide').show();
     } else if (options.url === "/plugins/dynamix.vm.manager/include/VMMachines.php" && !loadedFolder) {
         jqXHR.promise().then(async () => {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -781,11 +781,14 @@ const createFolderBtn = () => fv3CreateFolderBtn('vm', '/VMs/Folder');
 
 // Intercept Unraid's UserPrefs request to rewrite folder/order numbers — required for autostart and draw order.
 let fv3OrderSnapshotChain = Promise.resolve();
+let fv3OrderSnapshotGen = 0;
 $.ajaxPrefilter((options, originalOptions, jqXHR) => {
     if (options.url === "/plugins/dynamix.vm.manager/include/UserPrefs.php") {
         const data = new URLSearchParams(options.data);
         if (!data.has('names')) {
-            // Reset Order POST has only {reset:true} — nothing to renumber, let it through.
+            // Reset Order POST has only {reset:true} — nothing to renumber, let it through,
+            // and invalidate queued snapshot posts so a stale pre-reset order can't be saved.
+            fv3OrderSnapshotGen++;
             return;
         }
         const containers = data.get('names').split(';');
@@ -803,8 +806,11 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php).
         // Chained so a delayed earlier snapshot can't land after (and overwrite) a newer one.
         const fv3SnapshotNames = data.get('names');
+        const fv3SnapshotGen = fv3OrderSnapshotGen;
         fv3OrderSnapshotChain = fv3OrderSnapshotChain.then(() =>
-            $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: fv3SnapshotNames})
+            fv3SnapshotGen === fv3OrderSnapshotGen
+                ? $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: fv3SnapshotNames})
+                : undefined
         ).catch(() => {});
         $('.unhide').show();
     } else if (options.url === "/plugins/dynamix.vm.manager/include/VMMachines.php" && !loadedFolder) {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -799,7 +799,8 @@ $.ajaxPrefilter((options, originalOptions, jqXHR) => {
         options.data = data.toString();
         // Snapshot the interleaved order into FV3's own config so a reinstall can
         // restore folder positions after the uninstall prefs cleanup (server-side heal)
-        $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: data.get('names'), csrf_token: typeof csrf_token !== 'undefined' ? csrf_token : ''});
+        // csrf_token is auto-attached by webGui's global ajaxPrefilter (HeadInlineJS.php)
+        $.post('/plugins/folder.view3/server/update_order.php', {type: 'vm', names: data.get('names')});
         $('.unhide').show();
     } else if (options.url === "/plugins/dynamix.vm.manager/include/VMMachines.php" && !loadedFolder) {
         jqXHR.promise().then(async () => {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -46,8 +46,10 @@
         @file_put_contents($fv3_debug_log_file, "--- FolderView3 lib.php readInfo Start ---\n");
     }
 
-    function fv3_validate_type(string $type): string {
-        if (!in_array($type, ['docker', 'vm'], true)) {
+    function fv3_validate_type($type): string {
+        // Untyped on purpose: a crafted type[]=x request reaches every endpoint as an
+        // array, and a string-typed parameter would fatal (TypeError) instead of 400ing.
+        if (!is_string($type) || !in_array($type, ['docker', 'vm'], true)) {
             http_response_code(400);
             exit;
         }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -221,7 +221,13 @@
         if (!file_exists($path)) return [];
         $raw = @file_get_contents($path);
         $data = ($raw !== false) ? json_decode($raw, true) : null;
-        if (!is_array($data) || !isset($data['entries']) || !is_array($data['entries'])) return null;
+        if (!is_array($data) || ($data['fv3_order_version'] ?? null) !== 1
+            || !isset($data['entries']) || !is_array($data['entries'])) return null;
+        // saveOrderSnapshot never writes an empty or unsanitary list — anything that fails
+        // its own rules is not our file (corrupt/tampered), so omit it rather than export
+        // a present-empty key that would clear the destination snapshot on import.
+        $clean = fv3_sanitize_order_entries($data['entries']);
+        if ($clean === null || empty($clean) || $clean !== array_values($data['entries'])) return null;
         return $data;
     }
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1075,16 +1075,26 @@
             // Order snapshots go through saveOrderSnapshot so imported entries get the same sanitization as live saves
             if ($key === 'order_docker' || $key === 'order_vm') {
                 $t = $key === 'order_docker' ? 'docker' : 'vm';
+                // Re-confine before the deletes/writes below: refuse if the config dir
+                // path resolves through a symlink (realpath must equal the literal).
+                if (realpath($configDir) !== $configDir) { continue; }
+                $snapFile = fv3_order_snapshot_file($t);
                 $entries = (isset($data['entries']) && is_array($data['entries'])) ? $data['entries'] : [];
                 if (empty($entries)) {
                     // The bundle explicitly carries no snapshot (source box never saved one) —
                     // clear any pre-existing destination snapshot so it can't position the
                     // freshly imported folders with unrelated order data. A bundle without
                     // the key at all (pre-snapshot export) leaves the destination untouched.
-                    if (@unlink(fv3_order_snapshot_file($t))) { $restored[] = "order-$t.json (cleared)"; }
+                    if (@unlink($snapFile)) { $restored[] = "order-$t.json (cleared)"; }
                     continue;
                 }
-                if (saveOrderSnapshot($t, $entries)) { $restored[] = "order-$t.json"; }
+                if (saveOrderSnapshot($t, $entries)) {
+                    $restored[] = "order-$t.json";
+                } else {
+                    // Failed restore: drop any stale destination snapshot rather than let
+                    // it position the imported folders with unrelated order data.
+                    @unlink($snapFile);
+                }
                 continue;
             }
             // Folder maps are id => folder — allowlist the id keys (same charset as update.php) so a crafted

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1116,7 +1116,13 @@
                     // Exactly [] is how export represents "source has no snapshot" — clear any
                     // pre-existing destination snapshot so it can't position the freshly
                     // imported folders. A bundle without the key leaves the destination alone.
-                    if (@unlink($snapFile)) { $restored[] = "order-$t.json (cleared)"; }
+                    if (file_exists($snapFile)) {
+                        if (!@unlink($snapFile)) {
+                            // A stale snapshot the bundle said to remove must not survive a "success"
+                            return ['error' => "Could not clear order-$t.json — remove it manually (earlier sections were imported)"];
+                        }
+                        $restored[] = "order-$t.json (cleared)";
+                    }
                     continue;
                 }
                 // Same validation as export: a malformed wrapper is corrupt/tampered input and
@@ -1129,7 +1135,9 @@
                     // Validated entries can only fail on the atomic write itself; the source
                     // provably had a different snapshot, so drop the stale destination copy
                     // rather than let it position the imported folders (heal simply disables).
-                    @unlink($snapFile);
+                    if (file_exists($snapFile) && !@unlink($snapFile)) {
+                        return ['error' => "Could not update order-$t.json — remove it manually (earlier sections were imported)"];
+                    }
                 }
                 continue;
             }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1076,7 +1076,15 @@
             if ($key === 'order_docker' || $key === 'order_vm') {
                 $t = $key === 'order_docker' ? 'docker' : 'vm';
                 $entries = (isset($data['entries']) && is_array($data['entries'])) ? $data['entries'] : [];
-                if (!empty($entries) && saveOrderSnapshot($t, $entries)) { $restored[] = "order-$t.json"; }
+                if (empty($entries)) {
+                    // The bundle explicitly carries no snapshot (source box never saved one) —
+                    // clear any pre-existing destination snapshot so it can't position the
+                    // freshly imported folders with unrelated order data. A bundle without
+                    // the key at all (pre-snapshot export) leaves the destination untouched.
+                    if (@unlink(fv3_order_snapshot_file($t))) { $restored[] = "order-$t.json (cleared)"; }
+                    continue;
+                }
+                if (saveOrderSnapshot($t, $entries)) { $restored[] = "order-$t.json"; }
                 continue;
             }
             // Folder maps are id => folder — allowlist the id keys (same charset as update.php) so a crafted

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -173,8 +173,78 @@
         elseif($type == 'vm') { $prefsFilePath = "$userPrefsDir/dynamix.vm.manager/userprefs.cfg"; }
         else { return '[]'; }
         if(!file_exists($prefsFilePath)) { return '[]'; }
+        fv3_heal_user_prefs($type, $prefsFilePath);
         $parsedIni = @parse_ini_file($prefsFilePath);
         return json_encode(array_values($parsedIni ?: []));
+    }
+
+    function fv3_order_snapshot_file(string $type): string {
+        global $configDir;
+        return "$configDir/order-$type.json";
+    }
+
+    function saveOrderSnapshot(string $type, array $entries): bool {
+        $clean = [];
+        foreach ($entries as $e) {
+            if (!is_string($e)) continue;
+            $e = trim($e);
+            // Skip anything that could corrupt an ini line when healed back into userprefs.cfg
+            if ($e === '' || strlen($e) > 256 || strpos($e, '"') !== false || preg_match('/[\x00-\x1f\x7f]/', $e)) continue;
+            $clean[] = $e;
+            if (count($clean) >= 4096) break;
+        }
+        if (empty($clean)) return false;
+        return fv3_atomic_write(fv3_order_snapshot_file($type), json_encode(['fv3_order_version' => 1, 'entries' => $clean], JSON_PRETTY_PRINT));
+    }
+
+    // Re-insert folder rows into the stock sort prefs from FV3's own order snapshot.
+    // Fires only in the post-reinstall state: prefs has entries but positions no live
+    // folder, and a snapshot mentions live folders. Insert-only — existing prefs
+    // entries are never reordered or removed, so container order is preserved.
+    function fv3_heal_user_prefs(string $type, string $prefsFilePath): void {
+        global $configDir;
+        $parsed = @parse_ini_file($prefsFilePath);
+        if (!is_array($parsed) || empty($parsed)) return;
+        uksort($parsed, function($a, $b) { return (int)$a <=> (int)$b; });
+        $current = array_values($parsed);
+
+        $config = fv3_read_json("$configDir/$type.json");
+        if (empty($config)) return;
+        foreach ($current as $v) { if (isset($config[$v])) return; }
+
+        $snap = fv3_read_json(fv3_order_snapshot_file($type));
+        $saved = $snap['entries'] ?? null;
+        if (!is_array($saved)) return;
+
+        $currentSet = array_flip($current);
+        // Each live folder id maps to the first later snapshot entry still present in prefs (null = append)
+        $insertBefore = [];
+        $pending = [];
+        foreach ($saved as $entry) {
+            if (!is_string($entry)) continue;
+            if (isset($config[$entry])) { $pending[] = $entry; continue; }
+            if (isset($currentSet[$entry])) {
+                foreach ($pending as $fid) { $insertBefore[$fid] = $entry; }
+                $pending = [];
+            }
+        }
+        foreach ($pending as $fid) { $insertBefore[$fid] = null; }
+        if (empty($insertBefore)) return;
+
+        $out = [];
+        foreach ($current as $name) {
+            foreach ($insertBefore as $fid => $succ) {
+                if ($succ === $name) { $out[] = $fid; unset($insertBefore[$fid]); }
+            }
+            $out[] = $name;
+        }
+        foreach (array_keys($insertBefore) as $fid) { $out[] = $fid; }
+
+        $lines = [];
+        foreach (array_values($out) as $i => $name) { $lines[] = $i . '="' . $name . '"'; }
+        if (fv3_atomic_write($prefsFilePath, implode("\n", $lines) . "\n")) {
+            fv3_debug_log("fv3_heal_user_prefs($type): re-inserted " . (count($out) - count($current)) . " folder position(s)");
+        }
     }
 
     function fv3_autostart_file(): string {
@@ -942,6 +1012,8 @@
             'settings' => fv3_read_json("$configDir/settings.json"),
             'autostart' => fv3_read_json("$configDir/autostart.json"),
             'css_config' => fv3_read_json("$configDir/css-config.json"),
+            'order_docker' => fv3_read_json("$configDir/order-docker.json"),
+            'order_vm' => fv3_read_json("$configDir/order-vm.json"),
             'custom_styles' => []
         ];
         $stylesDir = "$configDir/styles";
@@ -976,9 +1048,16 @@
         if (!$bundle || !isset($bundle['fv3_export_version'])) return ['error' => 'Invalid FV3 export file'];
         $restored = [];
         if (!is_dir($configDir)) @mkdir($configDir, 0770, true);
-        foreach (['docker', 'vm', 'settings', 'autostart', 'css_config'] as $key) {
+        foreach (['docker', 'vm', 'settings', 'autostart', 'css_config', 'order_docker', 'order_vm'] as $key) {
             if (!isset($bundle[$key]) || !is_array($bundle[$key])) continue;
             $data = $bundle[$key];
+            // Order snapshots go through saveOrderSnapshot so imported entries get the same sanitization as live saves
+            if ($key === 'order_docker' || $key === 'order_vm') {
+                $t = $key === 'order_docker' ? 'docker' : 'vm';
+                $entries = (isset($data['entries']) && is_array($data['entries'])) ? $data['entries'] : [];
+                if (!empty($entries) && saveOrderSnapshot($t, $entries)) { $restored[] = "order-$t.json"; }
+                continue;
+            }
             // Folder maps are id => folder — allowlist the id keys (same charset as update.php) so a crafted
             // backup can't plant a folder id that breaks out of the class/onclick attributes at render (XSS).
             if ($key === 'docker' || $key === 'vm') {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -212,6 +212,19 @@
         return fv3_atomic_write(fv3_order_snapshot_file($type), json_encode(['fv3_order_version' => 1, 'entries' => $clean], JSON_PRETTY_PRINT));
     }
 
+    // Snapshot state for export, keeping the tri-state importAll() relies on:
+    // absent file -> [] (present-empty: source authoritatively has no snapshot, import
+    // clears the destination); unreadable/malformed -> null (omit the bundle key, import
+    // leaves the destination untouched); valid -> the wrapped snapshot.
+    function fv3_export_order_snapshot(string $type): ?array {
+        $path = fv3_order_snapshot_file($type);
+        if (!file_exists($path)) return [];
+        $raw = @file_get_contents($path);
+        $data = ($raw !== false) ? json_decode($raw, true) : null;
+        if (!is_array($data) || !isset($data['entries']) || !is_array($data['entries'])) return null;
+        return $data;
+    }
+
     // Re-insert folder rows into the stock sort prefs from FV3's own order snapshot.
     // Fires when prefs has entries but at least one live folder is unpositioned —
     // the post-reinstall state, or a folder whose entry went missing. Insert-only —
@@ -1037,10 +1050,12 @@
             'settings' => fv3_read_json("$configDir/settings.json"),
             'autostart' => fv3_read_json("$configDir/autostart.json"),
             'css_config' => fv3_read_json("$configDir/css-config.json"),
-            'order_docker' => fv3_read_json("$configDir/order-docker.json"),
-            'order_vm' => fv3_read_json("$configDir/order-vm.json"),
             'custom_styles' => []
         ];
+        foreach (['docker', 'vm'] as $ot) {
+            $snapExport = fv3_export_order_snapshot($ot);
+            if ($snapExport !== null) { $bundle["order_$ot"] = $snapExport; }
+        }
         $stylesDir = "$configDir/styles";
         $cssSize = 0;
         if (is_dir($stylesDir)) {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -209,9 +209,10 @@
     }
 
     // Re-insert folder rows into the stock sort prefs from FV3's own order snapshot.
-    // Fires only in the post-reinstall state: prefs has entries but positions no live
-    // folder, and a snapshot mentions live folders. Insert-only — existing prefs
-    // entries are never reordered or removed, so container order is preserved.
+    // Fires when prefs has entries but at least one live folder is unpositioned —
+    // the post-reinstall state, or a folder whose entry went missing. Insert-only —
+    // existing prefs entries are never reordered or removed, so container order is
+    // preserved, and already-positioned folders are kept in place and used as anchors.
     function fv3_heal_user_prefs(string $type, string $prefsFilePath): void {
         global $configDir;
         $parsed = @parse_ini_file($prefsFilePath);
@@ -221,19 +222,19 @@
 
         $config = fv3_read_json("$configDir/$type.json");
         if (empty($config)) return;
-        foreach ($current as $v) { if (isset($config[$v])) return; }
+        if (empty(array_diff(array_keys($config), $current))) return;
 
         $snap = fv3_read_json(fv3_order_snapshot_file($type));
         $saved = $snap['entries'] ?? null;
         if (!is_array($saved)) return;
 
         $currentSet = array_flip($current);
-        // Each live folder id maps to the first later snapshot entry still present in prefs (null = append)
+        // Each unpositioned live folder id maps to the first later snapshot entry still present in prefs (null = append)
         $insertBefore = [];
         $pending = [];
         foreach ($saved as $entry) {
             if (!is_string($entry)) continue;
-            if (isset($config[$entry])) { $pending[] = $entry; continue; }
+            if (isset($config[$entry]) && !isset($currentSet[$entry])) { $pending[] = $entry; continue; }
             if (isset($currentSet[$entry])) {
                 foreach ($pending as $fid) { $insertBefore[$fid] = $entry; }
                 $pending = [];

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -216,18 +216,25 @@
     // absent file -> [] (present-empty: source authoritatively has no snapshot, import
     // clears the destination); unreadable/malformed -> null (omit the bundle key, import
     // leaves the destination untouched); valid -> the wrapped snapshot.
+    // A snapshot wrapper saveOrderSnapshot could actually have written: version 1 and a
+    // non-empty entries list that passes sanitization unchanged. Returns the entries or
+    // null. Shared by export (file contents) and import (bundle contents) so both sides
+    // apply identical validation — anything else is corrupt/tampered and must be ignored,
+    // never treated as empty (that would clear a valid destination snapshot on import).
+    function fv3_validate_order_snapshot(array $data): ?array {
+        if (($data['fv3_order_version'] ?? null) !== 1
+            || !isset($data['entries']) || !is_array($data['entries'])) return null;
+        $clean = fv3_sanitize_order_entries($data['entries']);
+        if ($clean === null || empty($clean) || $clean !== array_values($data['entries'])) return null;
+        return $clean;
+    }
+
     function fv3_export_order_snapshot(string $type): ?array {
         $path = fv3_order_snapshot_file($type);
         if (!file_exists($path)) return [];
         $raw = @file_get_contents($path);
         $data = ($raw !== false) ? json_decode($raw, true) : null;
-        if (!is_array($data) || ($data['fv3_order_version'] ?? null) !== 1
-            || !isset($data['entries']) || !is_array($data['entries'])) return null;
-        // saveOrderSnapshot never writes an empty or unsanitary list — anything that fails
-        // its own rules is not our file (corrupt/tampered), so omit it rather than export
-        // a present-empty key that would clear the destination snapshot on import.
-        $clean = fv3_sanitize_order_entries($data['entries']);
-        if ($clean === null || empty($clean) || $clean !== array_values($data['entries'])) return null;
+        if (!is_array($data) || fv3_validate_order_snapshot($data) === null) return null;
         return $data;
     }
 
@@ -1094,40 +1101,46 @@
         if (!$bundle || !isset($bundle['fv3_export_version'])) return ['error' => 'Invalid FV3 export file'];
         $restored = [];
         if (!is_dir($configDir)) @mkdir($configDir, 0770, true);
+        // Confinement gate for EVERY write below, not just the snapshot branch: refuse the
+        // whole import if the config dir path resolves through a symlink or doesn't exist.
+        if (realpath($configDir) !== $configDir) {
+            return ['error' => 'Plugin config directory failed its confinement check — import aborted'];
+        }
         foreach (['docker', 'vm', 'settings', 'autostart', 'css_config', 'order_docker', 'order_vm'] as $key) {
             if (!isset($bundle[$key]) || !is_array($bundle[$key])) continue;
             $data = $bundle[$key];
-            // Order snapshots go through saveOrderSnapshot so imported entries get the same sanitization as live saves
             if ($key === 'order_docker' || $key === 'order_vm') {
                 $t = $key === 'order_docker' ? 'docker' : 'vm';
-                // Re-confine before the deletes/writes below: refuse if the config dir
-                // path resolves through a symlink (realpath must equal the literal).
-                if (realpath($configDir) !== $configDir) { continue; }
                 $snapFile = fv3_order_snapshot_file($t);
-                $entries = (isset($data['entries']) && is_array($data['entries'])) ? $data['entries'] : [];
-                if (empty($entries)) {
-                    // The bundle explicitly carries no snapshot (source box never saved one) —
-                    // clear any pre-existing destination snapshot so it can't position the
-                    // freshly imported folders with unrelated order data. A bundle without
-                    // the key at all (pre-snapshot export) leaves the destination untouched.
+                if ($data === []) {
+                    // Exactly [] is how export represents "source has no snapshot" — clear any
+                    // pre-existing destination snapshot so it can't position the freshly
+                    // imported folders. A bundle without the key leaves the destination alone.
                     if (@unlink($snapFile)) { $restored[] = "order-$t.json (cleared)"; }
                     continue;
                 }
+                // Same validation as export: a malformed wrapper is corrupt/tampered input and
+                // must not fall through to the clear branch or to a destructive restore.
+                $entries = fv3_validate_order_snapshot($data);
+                if ($entries === null) { continue; }
                 if (saveOrderSnapshot($t, $entries)) {
                     $restored[] = "order-$t.json";
                 } else {
-                    // Failed restore: drop any stale destination snapshot rather than let
-                    // it position the imported folders with unrelated order data.
+                    // Validated entries can only fail on the atomic write itself; the source
+                    // provably had a different snapshot, so drop the stale destination copy
+                    // rather than let it position the imported folders (heal simply disables).
                     @unlink($snapFile);
                 }
                 continue;
             }
-            // Folder maps are id => folder — allowlist the id keys (same charset as update.php) so a crafted
-            // backup can't plant a folder id that breaks out of the class/onclick attributes at render (XSS).
+            // Folder maps are id => folder — allowlist the id keys so a crafted backup can't
+            // plant a folder id that breaks out of class/onclick attributes at render (XSS).
+            // Alphanumeric ONLY: every generator (folder.view/2/3) strips +/= and never emits
+            // them, and an id containing +/= would break jQuery selectors at render time.
             if ($key === 'docker' || $key === 'vm') {
                 $clean = [];
                 foreach ($data as $fid => $folder) {
-                    if (is_string($fid) && preg_match('#^[A-Za-z0-9+/=]+$#D', $fid) && is_array($folder)) {
+                    if (is_string($fid) && preg_match('#^[A-Za-z0-9]+$#D', $fid) && is_array($folder)) {
                         $clean[$fid] = $folder;
                     }
                 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -185,17 +185,26 @@
         return "$configDir/order-$type.json";
     }
 
-    function saveOrderSnapshot(string $type, array $entries): bool {
+    // Returns the cleaned list, or null when any non-empty entry breaks the snapshot
+    // rules. Empty entries are delimiter artifacts (every stock names string ends ';')
+    // and are dropped, not treated as invalid. The rules exist because a violating
+    // entry could corrupt an ini line when healed back into userprefs.cfg.
+    function fv3_sanitize_order_entries(array $entries): ?array {
         $clean = [];
         foreach ($entries as $e) {
-            if (!is_string($e)) continue;
+            if (!is_string($e)) return null;
             $e = trim($e);
-            // Skip anything that could corrupt an ini line when healed back into userprefs.cfg
-            if ($e === '' || strlen($e) > 256 || strpos($e, '"') !== false || preg_match('/[\x00-\x1f\x7f]/', $e)) continue;
+            if ($e === '') continue;
+            if (strlen($e) > 256 || strpos($e, '"') !== false || preg_match('/[\x00-\x1f\x7f]/', $e)) return null;
             $clean[] = $e;
-            if (count($clean) >= 4096) break;
         }
-        if (empty($clean)) return false;
+        if (count($clean) > 4096) return null;
+        return $clean;
+    }
+
+    function saveOrderSnapshot(string $type, array $entries): bool {
+        $clean = fv3_sanitize_order_entries($entries);
+        if ($clean === null || empty($clean)) return false;
         return fv3_atomic_write(fv3_order_snapshot_file($type), json_encode(['fv3_order_version' => 1, 'entries' => $clean], JSON_PRETTY_PRINT));
     }
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -175,6 +175,10 @@
         elseif($type == 'vm') { $prefsFilePath = "$userPrefsDir/dynamix.vm.manager/userprefs.cfg"; }
         else { return '[]'; }
         if(!file_exists($prefsFilePath)) { return '[]'; }
+        // Deliberate GET side-effect (self-heal on the page-load read, mirroring the
+        // organizer mirror + rename-backfill pattern): content derives only from
+        // server-side state, is idempotent, and inserts rather than removes — a
+        // cross-site-triggered GET can only cause the same heal the next page load would.
         fv3_heal_user_prefs($type, $prefsFilePath);
         $parsedIni = @parse_ini_file($prefsFilePath);
         return json_encode(array_values($parsedIni ?: []));

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -222,19 +222,23 @@
 
         $config = fv3_read_json("$configDir/$type.json");
         if (empty($config)) return;
-        if (empty(array_diff(array_keys($config), $current))) return;
+        // Prefs and the snapshot store folder rows as 'folder-<id>' placeholders
+        // (the hidden appname the stock reorder serializes); config keys are raw ids.
+        $placeholders = [];
+        foreach (array_keys($config) as $fid) { $placeholders['folder-' . $fid] = true; }
+        if (empty(array_diff(array_keys($placeholders), $current))) return;
 
         $snap = fv3_read_json(fv3_order_snapshot_file($type));
         $saved = $snap['entries'] ?? null;
         if (!is_array($saved)) return;
 
         $currentSet = array_flip($current);
-        // Each unpositioned live folder id maps to the first later snapshot entry still present in prefs (null = append)
+        // Each unpositioned live folder placeholder maps to the first later snapshot entry still present in prefs (null = append)
         $insertBefore = [];
         $pending = [];
         foreach ($saved as $entry) {
             if (!is_string($entry)) continue;
-            if (isset($config[$entry]) && !isset($currentSet[$entry])) { $pending[] = $entry; continue; }
+            if (isset($placeholders[$entry]) && !isset($currentSet[$entry])) { $pending[] = $entry; continue; }
             if (isset($currentSet[$entry])) {
                 foreach ($pending as $fid) { $insertBefore[$fid] = $entry; }
                 $pending = [];

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -215,7 +215,9 @@
     // preserved, and already-positioned folders are kept in place and used as anchors.
     function fv3_heal_user_prefs(string $type, string $prefsFilePath): void {
         global $configDir;
-        $parsed = @parse_ini_file($prefsFilePath);
+        $raw = @file_get_contents($prefsFilePath);
+        if (!is_string($raw) || $raw === '') return;
+        $parsed = @parse_ini_string($raw);
         if (!is_array($parsed) || empty($parsed)) return;
         uksort($parsed, function($a, $b) { return (int)$a <=> (int)$b; });
         $current = array_values($parsed);
@@ -258,6 +260,9 @@
 
         $lines = [];
         foreach (array_values($out) as $i => $name) { $lines[] = $i . '="' . $name . '"'; }
+        // Stock UserPrefs writes are lockless, so re-check the source right before
+        // replacing — a concurrent reorder mid-compute aborts the heal (next load retries).
+        if (@file_get_contents($prefsFilePath) !== $raw) return;
         if (fv3_atomic_write($prefsFilePath, implode("\n", $lines) . "\n")) {
             fv3_debug_log("fv3_heal_user_prefs($type): re-inserted " . (count($out) - count($current)) . " folder position(s)");
         }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/update_order.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/update_order.php
@@ -1,0 +1,13 @@
+<?php
+    require_once("/usr/local/emhttp/plugins/folder.view3/server/lib.php");
+    fv3_post_init();
+    header('Content-Type: application/json');
+    $type = fv3_validate_type($_POST['type'] ?? '');
+    $names = $_POST['names'] ?? '';
+    if (!is_string($names) || $names === '' || strlen($names) > 65536) {
+        http_response_code(400);
+        echo json_encode(['error' => 'invalid names']);
+        exit;
+    }
+    echo json_encode(['success' => saveOrderSnapshot($type, explode(';', $names))]);
+?>

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/update_order.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/update_order.php
@@ -15,5 +15,10 @@
         echo json_encode(['error' => 'invalid names']);
         exit;
     }
-    echo json_encode(['success' => saveOrderSnapshot($type, $entries)]);
+    if (!saveOrderSnapshot($type, $entries)) {
+        http_response_code(500);
+        echo json_encode(['error' => 'snapshot write failed']);
+        exit;
+    }
+    echo json_encode(['success' => true]);
 ?>

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/update_order.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/update_order.php
@@ -9,5 +9,11 @@
         echo json_encode(['error' => 'invalid names']);
         exit;
     }
-    echo json_encode(['success' => saveOrderSnapshot($type, explode(';', $names))]);
+    $entries = fv3_sanitize_order_entries(explode(';', $names));
+    if ($entries === null || empty($entries)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'invalid names']);
+        exit;
+    }
+    echo json_encode(['success' => saveOrderSnapshot($type, $entries)]);
 ?>


### PR DESCRIPTION
## What

Folder/container layout now survives an uninstall → reinstall cycle. Every drag save snapshots the interleaved order (folder ids + container/VM names) into the plugin config, and on page load the plugin re-inserts folder position entries into the stock sort prefs when they're missing — the state the uninstall cleanup (#57) leaves behind.

## Why

Folder positions exist only as `folder-<id>` entries in dockerMan's / the VM manager's `userprefs.cfg`. #57 strips those on uninstall, and no FV3 backup carried them — so even a user who dutifully backed up their config got a scrambled Docker/VM page after reinstalling. This closes that gap: the config backup (directory copy or in-app export) now genuinely restores layout.

## How

- The existing UserPrefs prefilters (docker.js / vm.js) additionally POST the same names list to a new `server/update_order.php`, which sanitizes entries (length caps, no quotes/control chars) and writes `order-docker.json` / `order-vm.json` atomically. Reset Order posts carry no `names` and are untouched.
- `readUserPrefs()` (the single position source, served by `read_order.php` on every page load) first runs `fv3_heal_user_prefs()`: if prefs exist but position no live folder, and a snapshot mentions folders that exist in the current config, folder entries are re-inserted at their saved positions relative to surviving neighbours. An entry counts as a folder only by exact match against the config's folder ids — no pattern guessing.
- The heal is insert-only (container order is never reordered or pruned), idempotent (a positioned live folder disables it), skips stale/deleted folder ids, anchors past removed containers to the next surviving one, appends folders with no surviving successor, and ignores empty or missing prefs files so Reset Order semantics are preserved.
- `exportAll`/`importAll` now include both snapshots; imports pass through the same sanitizer as live saves.

## Testing

PHP CLI harness on a live Unraid 7.3.2 box (`php -l` clean on both files):

- Insertion: folders re-anchored correctly with a removed container between a folder and its successor, a stale folder id in the snapshot ignored, a new container preserved at its current position.
- Idempotence: second heal run is byte-identical.
- Reset state: empty prefs file untouched.
- Sanitization: empty/quoted/control-char/oversized entries dropped, order preserved.
- No snapshot present: no-op.

End-to-end (seed snapshot → strip folder entries → reload → layout restored) to be verified on the live box after the beta build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker and VM ordering is saved automatically and restored after preference updates or reloads.
  * Saved ordering is preserved when folder entries are missing or reinstalled.
  * Docker and VM order settings are included in export and import bundles.

* **Bug Fixes**
  * Improved reliability when saving multiple ordering changes in quick succession.
  * Reset actions now correctly supersede pending ordering updates.
  * Invalid, unsafe, or oversized ordering data is rejected with clear errors.
  * Improved recovery of folder entries without changing existing item order.
  * Added clearer handling for failed order-save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->