### PR TITLE
fix: explicit folder membership beats a Docker label claim

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/de.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/de.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "Kein Autostart",
     "autostart-col-container": "Container",
     "autostart-col-folder": "Ordner",
-    "autostart-col-wait": "Warten (s)"
+    "autostart-col-wait": "Warten (s)",
+    "label-claim-tooltip": "Durch ein folder.view3-Label beansprucht — eine explizite Ordnerzuweisung hat Vorrang"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/en.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/en.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "Not autostarted",
     "autostart-col-container": "Container",
     "autostart-col-folder": "Folder",
-    "autostart-col-wait": "Wait (s)"
+    "autostart-col-wait": "Wait (s)",
+    "label-claim-tooltip": "Claimed by a folder.view3 label — an explicit folder assignment anywhere overrides it"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/es.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/es.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "Sin autoarranque",
     "autostart-col-container": "Contenedor",
     "autostart-col-folder": "Carpeta",
-    "autostart-col-wait": "Espera (s)"
+    "autostart-col-wait": "Espera (s)",
+    "label-claim-tooltip": "Reclamado por una etiqueta folder.view3 — una asignación explícita a una carpeta tiene prioridad"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/fr.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/fr.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "Sans démarrage auto",
     "autostart-col-container": "Conteneur",
     "autostart-col-folder": "Dossier",
-    "autostart-col-wait": "Attente (s)"
+    "autostart-col-wait": "Attente (s)",
+    "label-claim-tooltip": "Revendiqué par une étiquette folder.view3 — une affectation explicite à un dossier est prioritaire"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/it.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/it.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "Senza avvio automatico",
     "autostart-col-container": "Container",
     "autostart-col-folder": "Cartella",
-    "autostart-col-wait": "Attesa (s)"
+    "autostart-col-wait": "Attesa (s)",
+    "label-claim-tooltip": "Rivendicato da un'etichetta folder.view3 — un'assegnazione esplicita a una cartella ha la precedenza"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/pl.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/pl.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "Bez autostartu",
     "autostart-col-container": "Kontener",
     "autostart-col-folder": "Folder",
-    "autostart-col-wait": "Oczekiwanie (s)"
+    "autostart-col-wait": "Oczekiwanie (s)",
+    "label-claim-tooltip": "Zajęty przez etykietę folder.view3 — jawne przypisanie do folderu ma pierwszeństwo"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/zh.json
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/langs/zh.json
@@ -277,5 +277,6 @@
     "autostart-not-started": "未自动启动",
     "autostart-col-container": "容器",
     "autostart-col-folder": "文件夹",
-    "autostart-col-wait": "等待（秒）"
+    "autostart-col-wait": "等待（秒）",
+    "label-claim-tooltip": "已被 folder.view3 标签认领 — 明确的文件夹分配将优先于标签"
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
@@ -42,14 +42,6 @@ const createFolders = async () => {
         fv3ResolveRenamedContainers(folders, containersInfo, 'docker');
         Object.values(folders).forEach(f => fv3ApplyDefaults(f));
 
-        // Explicit members + label claims of ANY folder beat regex matches elsewhere (issue #46);
-        // explicit members alone also beat label claims elsewhere (issue #55)
-        const fv3FolderNames = new Set(Object.values(folders).map(f => f.name));
-        const fv3ExplicitMembers = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : []);
-        const fv3AssignedElsewhere = fv3ExplicitMembers
-            .concat(Object.keys(containersInfo).filter(n => { const l = containersInfo[n]?.Labels?.['folder.view3']; return l && fv3FolderNames.has(l); }));
-        Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; f.fv3ExplicitMembers = fv3ExplicitMembers; });
-
         let newOnes = order.filter(x => !unraidOrder.includes(x));
 
         for (let index = 0; index < unraidOrder.length; index++) {
@@ -77,6 +69,14 @@ const createFolders = async () => {
             order: order,
             containersInfo: containersInfo
         }}));
+
+        // Explicit members/label claims of ANY folder beat regex elsewhere (#46); explicit beats label (#55).
+        // Must stay AFTER the pre-folders-creation dispatch — extensions may edit memberships there.
+        const fv3FolderNames = new Set(Object.values(folders).map(f => f.name));
+        const fv3ExplicitMembers = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : []);
+        const fv3AssignedElsewhere = fv3ExplicitMembers
+            .concat(Object.keys(containersInfo).filter(n => { const l = containersInfo[n]?.Labels?.['folder.view3']; return l && fv3FolderNames.has(l); }));
+        Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; f.fv3ExplicitMembers = fv3ExplicitMembers; });
 
         for (let key = 0; key < order.length; key++) {
             const container = order[key];

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
@@ -42,11 +42,13 @@ const createFolders = async () => {
         fv3ResolveRenamedContainers(folders, containersInfo, 'docker');
         Object.values(folders).forEach(f => fv3ApplyDefaults(f));
 
-        // Explicit members + label claims of ANY folder beat regex matches elsewhere (issue #46)
+        // Explicit members + label claims of ANY folder beat regex matches elsewhere (issue #46);
+        // explicit members alone also beat label claims elsewhere (issue #55)
         const fv3FolderNames = new Set(Object.values(folders).map(f => f.name));
-        const fv3AssignedElsewhere = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : [])
+        const fv3ExplicitMembers = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : []);
+        const fv3AssignedElsewhere = fv3ExplicitMembers
             .concat(Object.keys(containersInfo).filter(n => { const l = containersInfo[n]?.Labels?.['folder.view3']; return l && fv3FolderNames.has(l); }));
-        Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; });
+        Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; f.fv3ExplicitMembers = fv3ExplicitMembers; });
 
         let newOnes = order.filter(x => !unraidOrder.includes(x));
 
@@ -302,7 +304,8 @@ const createFolderDocker = (folder, id, position, order, containersInfo, folders
         } catch (e) { console.error('[FV3] Invalid regex:', folder.regex, e); }
     }
 
-    folder.containers = folder.containers.concat(order.filter(el => containersInfo[el]?.Labels['folder.view3'] === folder.name));
+    // Skip containers explicitly assigned to any folder — explicit beats label (issue #55)
+    folder.containers = folder.containers.concat(order.filter(el => containersInfo[el]?.Labels?.['folder.view3'] === folder.name && !folder.containers.includes(el) && !(folder.fv3ExplicitMembers || []).includes(el)));
 
     const fld = `<div class="folder-showcase-outer-${id} folder-showcase-outer"><span class="outer solid apps stopped folder-docker"><span id="folder-id-${id}" onclick='addDockerFolderContext("${id}")' class="hand docker folder-hand-docker fv3-folder-hand fv3-folder-hand-docker"><img src="${escapeHtml(folder.icon || '/plugins/dynamix.docker.manager/images/question.png')}" class="img folder-img-docker fv3-folder-icon fv3-folder-icon-docker" onerror="this.onerror=null;this.src='/plugins/dynamix.docker.manager/images/question.png';"></span><span class="inner folder-inner-docker fv3-folder-inner fv3-folder-inner-docker"><span class="folder-appname-docker fv3-folder-appname fv3-folder-appname-docker">${escapeHtml(folder.name)}</span><br><i class="fa fa-square stopped red-text folder-load-status-docker fv3-folder-status-icon fv3-folder-status-icon-docker"></i><span class="state folder-state-docker fv3-folder-state fv3-folder-state-docker">${$.i18n('stopped')}</span></span><div class="folder-storage fv3-folder-storage"></div></span><div class="folder-showcase-${id} folder-showcase fv3-folder-showcase" data-folder-name="${escapeHtml(folder.name)}"></div></div>`;
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -29,11 +29,13 @@ const createFolders = async () => {
     fv3ResolveRenamedContainers(folders, containersInfo, 'docker');
     Object.values(folders).forEach(f => fv3ApplyDefaults(f));
 
-    // Explicit members + label claims of ANY folder beat regex matches elsewhere (issue #46)
+    // Explicit members + label claims of ANY folder beat regex matches elsewhere (issue #46);
+    // explicit members alone also beat label claims elsewhere (issue #55)
     const fv3FolderNames = new Set(Object.values(folders).map(f => f.name));
-    const fv3AssignedElsewhere = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : [])
+    const fv3ExplicitMembers = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : []);
+    const fv3AssignedElsewhere = fv3ExplicitMembers
         .concat(Object.keys(containersInfo).filter(n => { const l = containersInfo[n]?.Labels?.['folder.view3']; return l && fv3FolderNames.has(l); }));
-    Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; });
+    Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; f.fv3ExplicitMembers = fv3ExplicitMembers; });
 
     // No userprefs.cfg: synthesize alphabetical intermix of folder names + orphan containers.
     // Note: `unraidOrder` = read_order.php (raw prefs, has folder placeholders); `order` =
@@ -302,7 +304,8 @@ const createFolder = (folder, id, positionInMainOrder, liveOrderArray, container
         if (folder.regex) fv3Debug('createFolder', id, 'regex present but empty/invalid, skipping');
     }
 
-    const labelMatches = orderSnapshotAtFolderStart.filter(el => containersInfo[el]?.Labels?.['folder.view3'] === folder.name && !combinedContainers.includes(el));
+    // Skip containers explicitly assigned to any folder — explicit beats label (issue #55)
+    const labelMatches = orderSnapshotAtFolderStart.filter(el => containersInfo[el]?.Labels?.['folder.view3'] === folder.name && !combinedContainers.includes(el) && !(folder.fv3ExplicitMembers || []).includes(el));
     labelMatches.forEach(match => combinedContainers.push(match));
 
     fv3Debug('createFolder', id, 'label matches', labelMatches);

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -29,14 +29,6 @@ const createFolders = async () => {
     fv3ResolveRenamedContainers(folders, containersInfo, 'docker');
     Object.values(folders).forEach(f => fv3ApplyDefaults(f));
 
-    // Explicit members + label claims of ANY folder beat regex matches elsewhere (issue #46);
-    // explicit members alone also beat label claims elsewhere (issue #55)
-    const fv3FolderNames = new Set(Object.values(folders).map(f => f.name));
-    const fv3ExplicitMembers = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : []);
-    const fv3AssignedElsewhere = fv3ExplicitMembers
-        .concat(Object.keys(containersInfo).filter(n => { const l = containersInfo[n]?.Labels?.['folder.view3']; return l && fv3FolderNames.has(l); }));
-    Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; f.fv3ExplicitMembers = fv3ExplicitMembers; });
-
     // No userprefs.cfg: synthesize alphabetical intermix of folder names + orphan containers.
     // Note: `unraidOrder` = read_order.php (raw prefs, has folder placeholders); `order` =
     // read_unraid_order.php (containers only, alphabetical when prefs absent).
@@ -117,6 +109,14 @@ const createFolders = async () => {
         order: order,
         containersInfo: containersInfo
     }}));
+
+    // Explicit members/label claims of ANY folder beat regex elsewhere (#46); explicit beats label (#55).
+    // Must stay AFTER the pre-folders-creation dispatch — extensions may edit memberships there.
+    const fv3FolderNames = new Set(Object.values(folders).map(f => f.name));
+    const fv3ExplicitMembers = Object.values(folders).flatMap(f => Array.isArray(f.containers) ? f.containers : []);
+    const fv3AssignedElsewhere = fv3ExplicitMembers
+        .concat(Object.keys(containersInfo).filter(n => { const l = containersInfo[n]?.Labels?.['folder.view3']; return l && fv3FolderNames.has(l); }));
+    Object.values(folders).forEach(f => { f.fv3AssignedElsewhere = fv3AssignedElsewhere; f.fv3ExplicitMembers = fv3ExplicitMembers; });
 
     fv3Debug('createFolders', 'Starting loop to draw folders in order.');
     for (let key = 0; key < order.length; key++) {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folder.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folder.js
@@ -32,6 +32,7 @@ let selectedRegex = [];
 let selected = [];
 let hiddenPreview = [];
 let labelFolderNames = new Set();
+let otherExplicitMembers = new Set();
 const type = new URLSearchParams(location.search).get('type');
 const folderId = new URLSearchParams(location.search).get('id');
 
@@ -70,6 +71,9 @@ $('div.canvas > form')[0].preview_vertical_bars_color.value = rgbToHex($('body')
     }
     let folders = fv3SafeParse(await $.get(`/plugins/folder.view3/server/read.php?type=${type}`).promise(), {});
     labelFolderNames = new Set(Object.values(folders).map(f => f.name));
+    // Other folders' explicit containers[] — their claims beat label/regex here (issue #55).
+    // Must be set before the edit-branch updateRegex() call below, which runs pre-prune.
+    otherExplicitMembers = new Set(Object.entries(folders).filter(([fid]) => fid !== folderId).flatMap(([, f]) => Array.isArray(f.containers) ? f.containers : []));
     let typeFilter;
     if (type === 'docker') {
         typeFilter = (e) => {
@@ -272,14 +276,15 @@ const updateIcon = (e) => {
 const updateRegex = (e) => {
     choose = choose.concat(selectedRegex);
     const fldName = $('[name="name"]')[0].value;
-    selectedRegex = choose.filter(el => el.Label === fldName);
-    choose = choose.filter(el => el.Label !== fldName);
+    // A label claim is void for containers explicitly assigned to another folder (issue #55)
+    selectedRegex = choose.filter(el => el.Label === fldName && !otherExplicitMembers.has(el.Name));
+    choose = choose.filter(el => el.Label !== fldName || otherExplicitMembers.has(el.Name));
     if (e.value) {
         try {
             const regex = new RegExp(e.value);
             for (let i = 0; i < choose.length; i++) {
-                // Containers label-claimed by another folder can't be regex-captured (matches render, issue #46)
-                if (regex.test(choose[i].Name) && !(choose[i].Label && labelFolderNames.has(choose[i].Label))) {
+                // Containers label-claimed or explicitly assigned elsewhere can't be regex-captured (matches render, issues #46/#55)
+                if (regex.test(choose[i].Name) && !(choose[i].Label && labelFolderNames.has(choose[i].Label)) && !otherExplicitMembers.has(choose[i].Name)) {
                     const tmpSel = choose.splice(i, 1)[0];
                     if(!selectedRegex.includes(tmpSel)) {
                         selectedRegex.push(tmpSel);
@@ -345,7 +350,9 @@ const updateList = () => {
     }
 
     for (const el of choose) {
-        table.append($(`<tr class="item" draggable="true"><td><span style="cursor: pointer;" onclick="setIconAsContainer(this)"><img src="${escapeHtml(el.Icon || '/plugins/dynamix.docker.manager/images/question.png')}" class="img" onerror="this.onerror=null;this.src='/plugins/dynamix.docker.manager/images/question.png';"></span>${escapeHtml(el.Name)}</td><td><input class="container-switch fv3-checkbox" type="checkbox" name="containers[]" value="${escapeHtml(el.Name)}"></td><td></td></tr>`));
+        // fa-tag marker: this container carries a live label claim (issue #55)
+        const labelClaim = el.Label && labelFolderNames.has(el.Label) ? `<span class="fv3-label-claim" title="${escapeHtml($.i18n('label-claim-tooltip'))}" data-i18n="[title]label-claim-tooltip"><i class="fa fa-tag" aria-hidden="true"></i> ${escapeHtml(el.Label)}</span>` : '';
+        table.append($(`<tr class="item" draggable="true"><td><span style="cursor: pointer;" onclick="setIconAsContainer(this)"><img src="${escapeHtml(el.Icon || '/plugins/dynamix.docker.manager/images/question.png')}" class="img" onerror="this.onerror=null;this.src='/plugins/dynamix.docker.manager/images/question.png';"></span>${escapeHtml(el.Name)}${labelClaim}</td><td><input class="container-switch fv3-checkbox" type="checkbox" name="containers[]" value="${escapeHtml(el.Name)}"></td><td></td></tr>`));
     }
 
     for (const el of selectedRegex) {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -499,6 +499,14 @@
             if (isset($folder['name'])) { $folderNameSet[$folder['name']] = true; }
         }
 
+        // A corrupt persisted shape must abort before the autostart write, not fatal mid-sync
+        foreach ($folders as $folder) {
+            if (!is_array($folder) || !is_array($folder['containers'] ?? [])) {
+                fv3_debug_log("syncContainerOrder: folder entry with invalid containers shape, aborting before write");
+                return;
+            }
+        }
+
         $folderContainers = [];
         $folderNames = [];
         $assignedContainers = [];

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -502,11 +502,13 @@
         $folderContainers = [];
         $folderNames = [];
         $assignedContainers = [];
-        // Explicit members and label claims of any folder beat regex matches elsewhere (issue #46)
-        $explicitAssigned = [];
+        // Explicit members and label claims of any folder beat regex matches elsewhere (issue #46);
+        // explicit members alone also beat label claims elsewhere (issue #55)
+        $explicitMembers = [];
         foreach ($folders as $folder) {
-            $explicitAssigned = array_merge($explicitAssigned, $folder['containers'] ?? []);
+            $explicitMembers = array_merge($explicitMembers, $folder['containers'] ?? []);
         }
+        $explicitAssigned = $explicitMembers;
         foreach ($ctLabels as $ctName => $ctLabel) {
             if (isset($folderNameSet[$ctLabel])) { $explicitAssigned[] = $ctName; }
         }
@@ -523,8 +525,9 @@
                     }
                 }
             }
+            // Explicit containers[] entries anywhere win over a label claim (issue #55)
             foreach ($ctLabels as $ctName => $ctLabel) {
-                if ($ctLabel === ($folder['name'] ?? null) && !in_array($ctName, $members)) {
+                if ($ctLabel === ($folder['name'] ?? null) && !in_array($ctName, $members) && !in_array($ctName, $explicitMembers)) {
                     $members[] = $ctName;
                 }
             }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/styles/folder.css
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/styles/folder.css
@@ -190,7 +190,7 @@ table.sortable td:last-child {
 .fv3-label-claim {
     margin-left: 0.6em;
     font-size: 0.85em;
-    opacity: 0.6;
+    color: var(--orange-500, #ff8c2f);
     white-space: nowrap;
     cursor: help;
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/styles/folder.css
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/styles/folder.css
@@ -190,7 +190,7 @@ table.sortable td:last-child {
 .fv3-label-claim {
     margin-left: 0.6em;
     font-size: 0.85em;
-    color: var(--orange-500, #ff8c2f);
+    color: var(--orange-500, inherit);
     white-space: nowrap;
     cursor: help;
 }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/styles/folder.css
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/styles/folder.css
@@ -186,6 +186,15 @@ table.sortable td:last-child {
     text-align: center;
 }
 
+/* fa-tag claim marker rendered by updateList() for label-claimed containers (issue #55) */
+.fv3-label-claim {
+    margin-left: 0.6em;
+    font-size: 0.85em;
+    opacity: 0.6;
+    white-space: nowrap;
+    cursor: help;
+}
+
 table.sortable td .switch-button-background,
 table.sortable td .fv3-toggle {
     float: none;


### PR DESCRIPTION
A container explicitly assigned to folder A and label-claimed by folder B resolved by iteration order — arbitrarily, and differently between the client and the server (PHP walks `docker.json` key order, the pages render in display order). Raised by review on #54 and deferred there so that PR didn't fix one side and add a new divergence.

This makes explicit `containers[]` membership void a label claim in all three membership calculations in one change:

- `docker.js` — the #46 assigned-elsewhere set now also exposes its explicit-only subset (`fv3ExplicitMembers`); label matching skips containers in it.
- `dashboard.js` — same change (the issue named only docker.js and lib.php, but the dashboard has its own copy of the label matching). Its label match also gains the self-dedup guard docker.js already had — a container both explicit in a folder and labelled for it was concat'd into the showcase twice — plus the `?.Labels?.` optional chaining used elsewhere in the file.
- `lib.php` — `syncContainerOrder()` builds the explicit-only set first and the label-claim loop skips names in it. The #46 regex gate keeps its old semantics, and all the fail-closed guards are untouched.

Resulting precedence everywhere: explicit > label > regex.

The folder editor is aligned with the new semantics: a container explicitly owned by another folder is no longer shown as label-locked or regex-captured (previously it rendered `checked disabled` as if this folder owned it, escaping the foreign-members prune, which only filters `choose`). Rows that carry a live label claim now show a small tag marker with the claiming folder's name and a tooltip explaining the precedence — new `label-claim-tooltip` key in all 7 language files, one theme-agnostic rule in `folder.css`.

Tested live on Unraid (beta 2026.08.28.1, autostart mode `folder`) with two throwaway folders and never-started containers, control first:

- stock `lib.php`: the contested container grouped under the label folder — iteration order won — autostart order `fv3anchor, fv3test`
- patched `lib.php`, same seed: grouped under its explicit folder — `fv3test, fv3anchor`
- explicit entry removed (label-only): grouped back under the label folder, so plain label claims still work

All three acceptance criteria from #55 hold. Config, autostart file and `lib.php` were restored byte-identical afterwards. Client side verified by trace plus `node --check` and the JS invariant checks.

Out of scope, noted while here:

- The Autostart tab's Folder column (`fv3AsFolderOf`) has only ever reflected explicit members — a label-claimed container shows an empty badge there. Pre-existing display gap, worth its own issue.
- Dual *explicit* membership (possible only via hand-edited or imported JSON — the editor prunes foreign members) still resolves first-wins.

Closes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit folder assignments now take precedence over label- and pattern-based claims.
  * Added a visual marker for containers assigned through labels.
  * Added explanatory tooltips for label claims and assignment priority.
  * Improved folder synchronization safeguards when assignment data is invalid.

* **Localization**
  * Added or updated translations for assignment guidance and autostart wait labels across supported languages.

* **Style**
  * Improved label-claim marker visibility and usability with spacing, opacity, non-wrapping text, and a help cursor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->