### PR TITLE
fix: enforce single-owner explicit membership at every folder write sink

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1313,8 +1313,11 @@
             if ($key === 'docker' || $key === 'vm') {
                 $clean = [];
                 foreach ($data as $fid => $folder) {
-                    if (is_string($fid) && preg_match('#^[A-Za-z0-9]+$#D', $fid) && is_array($folder)) {
-                        $clean[$fid] = $folder;
+                    // (string) not is_string: json_decode gives an all-digit id an int key, which
+                    // the old check dropped — silently discarding that folder and reporting success
+                    $sid = (string)$fid;
+                    if (preg_match('#^[A-Za-z0-9]+$#D', $sid) && is_array($folder)) {
+                        $clean[$sid] = $folder;
                     }
                 }
                 // Imported bundles (and folder.view2 exports) can hold one container in two

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -707,6 +707,31 @@
         }
     }
 
+    // A container may be explicit in at most one folder (issue #62). $winnerId's list survives
+    // intact (the folder just saved wins); elsewhere ties resolve first-wins in key order.
+    function fv3_dedupe_explicit_members(array $folders, ?string $winnerId = null): array {
+        $claimed = [];
+        $winnerMembers = $winnerId !== null ? ($folders[$winnerId]['containers'] ?? null) : null;
+        if (is_array($winnerMembers)) {
+            foreach ($winnerMembers as $ct) {
+                if (is_string($ct)) { $claimed[$ct] = true; }
+            }
+        }
+        foreach ($folders as $fid => $folder) {
+            if ($fid === $winnerId || !is_array($folder['containers'] ?? null)) { continue; }
+            $kept = [];
+            foreach ($folder['containers'] as $ct) {
+                if (is_string($ct)) {
+                    if (isset($claimed[$ct])) { continue; }
+                    $claimed[$ct] = true;
+                }
+                $kept[] = $ct;
+            }
+            $folders[$fid]['containers'] = $kept;
+        }
+        return $folders;
+    }
+
     function updateFolder(string $type, string $content, string $id = '') : void {
         global $configDir;
         if(!file_exists("$configDir/$type.json")) { createFile($type); if (empty($id)) $id = generateId(); }
@@ -733,6 +758,7 @@
             exit;
         }
         $fileData[$id] = $decoded;
+        $fileData = fv3_dedupe_explicit_members($fileData, $id);
         $path = "$configDir/$type.json";
         fv3_atomic_write($path, json_encode($fileData));
     }
@@ -765,6 +791,8 @@
             }
         }
         if ($changed) {
+            // A rename can land on a name already explicit elsewhere — re-assert single ownership (issue #62)
+            $fileData = fv3_dedupe_explicit_members($fileData);
             $path = "$configDir/$type.json";
             fv3_atomic_write($path, json_encode($fileData));
         }
@@ -1278,7 +1306,9 @@
                         $clean[$fid] = $folder;
                     }
                 }
-                $data = $clean;
+                // Imported bundles (and folder.view2 exports) can hold one container in two
+                // folders — first folder in bundle order keeps it (issue #62)
+                $data = fv3_dedupe_explicit_members($clean);
             }
             $filename = $key === 'css_config' ? 'css-config.json' : "$key.json";
             $path = "$configDir/$filename";

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -768,7 +768,15 @@
         if(!file_exists("$configDir/$type.json")) { return; }
         $updates = json_decode($data, true);
         if (json_last_error() !== JSON_ERROR_NONE || !is_array($updates)) { http_response_code(400); exit; }
-        $fileData = fv3_read_json("$configDir/$type.json");
+        // Strict, like updateFolder: the dedupe below rewrites every folder, so a
+        // corrupt-as-empty read must abort rather than persist a pruned file
+        $fileData = fv3_read_json_strict("$configDir/$type.json");
+        if ($fileData === null) {
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => "$type.json is unreadable — refusing to save so existing folders are not wiped"]);
+            exit;
+        }
         $changed = false;
         foreach ($updates as $folderId => $patch) {
             if (!preg_match('/^[A-Za-z0-9+\/=]+$/', $folderId)) continue;

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -711,6 +711,9 @@
     // intact (the folder just saved wins); elsewhere ties resolve first-wins in key order.
     function fv3_dedupe_explicit_members(array $folders, ?string $winnerId = null): array {
         $claimed = [];
+        // PHP stores an all-digit id as an int key, so compare canonical strings below — on ===
+        // the winner would fail to match its own id and be stripped of the members claimed here
+        $winnerKey = $winnerId === null ? null : (string)$winnerId;
         $winnerMembers = $winnerId !== null ? ($folders[$winnerId]['containers'] ?? null) : null;
         if (is_array($winnerMembers)) {
             foreach ($winnerMembers as $ct) {
@@ -718,7 +721,7 @@
             }
         }
         foreach ($folders as $fid => $folder) {
-            if ($fid === $winnerId || !is_array($folder['containers'] ?? null)) { continue; }
+            if (($winnerKey !== null && (string)$fid === $winnerKey) || !is_array($folder['containers'] ?? null)) { continue; }
             $kept = [];
             foreach ($folder['containers'] as $ct) {
                 if (is_string($ct)) {


### PR DESCRIPTION
One container could appear in two folders' explicit `containers[]` lists — reachable through Import Everything bundles (including folder.view2-era exports), hand-edited `docker.json`/`vm.json`, or a container rename resolving onto a name already explicit in another folder. The editor itself prevents it, but once present each surface picked its own winner by processing order: `syncContainerOrder()` first-wins in JSON key order, the rendered tabs by display order. Same defect class #55 closed for explicit-vs-label, left open for explicit-vs-explicit.

This enforces single ownership at the write sinks instead of tie-breaking at every read site. A new `fv3_dedupe_explicit_members()` runs at all three places that write folder maps:

- `updateFolder()` (serves both create.php and update.php) — the folder being saved wins, since that's the user's latest deliberate action; its members are stripped from every other folder in the same atomic write
- `updateFolderIds()` — the rename-resolution path re-asserts the invariant after patching names (a rename can land on a name already explicit elsewhere); first-wins in key order
- `importAll()` — the imported docker/vm maps are deduped before writing, first folder in bundle key order wins, deterministic for a given file

Read sites never see a contested explicit claim, so no per-page resolution logic is needed and every surface agrees.

Verified on Unraid's PHP with fixture tests: winner-steals, first-wins, three-way contest with a middle winner, absent winner id, corrupt non-array `containers` passthrough without fatal, non-string entries preserved without claiming, and a duplicate-free map surviving byte-identical through both modes.

Closes #62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured explicitly assigned containers belong to only one folder at a time.
  - Preserved existing container memberships when updating or importing folders.
  - Prevented duplicate container assignments during folder imports.
  - Preserved numeric folder IDs during imports.
  - Prevented corrupted or unreadable configuration data from being treated as empty.
  - Added clearer failure handling when folder configuration cannot be read, including an appropriate error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->