### PR TITLE
fix: Autostart tab Folder badge reflects effective membership

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folderview3.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/folderview3.js
@@ -689,9 +689,15 @@ $('#fv3-import-all').on('change', function() {
 // ---- Autostart tab ----
 let fv3AsSnapshot = null;
 let fv3AsInfo = {};
+let fv3AsMembership = null;
 let fv3AsLoadStarted = false;
 
 const fv3AsFolderOf = (name) => {
+    // Server-computed effective membership — explicit > label > regex (issue #61);
+    // explicit-only scan is the fallback when that read failed.
+    if (fv3AsMembership) {
+        return Object.prototype.hasOwnProperty.call(fv3AsMembership, name) ? fv3AsMembership[name] : '';
+    }
     for (const folder of Object.values(dockers)) {
         if (Array.isArray(folder.containers) && folder.containers.includes(name)) return folder.name || '';
     }
@@ -791,10 +797,13 @@ const fv3AsBindOnce = () => {
 
 const fv3LoadAutostart = async () => {
     try {
-        const [as, info] = (await Promise.all([
+        const [as, info, memb] = (await Promise.all([
             $.get('/plugins/folder.view3/server/read_autostart.php').promise(),
-            $.get('/plugins/folder.view3/server/read_info.php?type=docker').promise()
+            $.get('/plugins/folder.view3/server/read_info.php?type=docker').promise(),
+            // badge enrichment only — a failed membership read must not break the tab
+            $.get('/plugins/folder.view3/server/read_membership.php?type=docker').promise().catch(() => null)
         ])).map(r => fv3SafeParse(r, {}));
+        fv3AsMembership = memb && typeof memb.membership === 'object' && memb.membership !== null ? memb.membership : null;
         fv3AsInfo = {};
         for (const [name, ct] of Object.entries(info)) {
             // only dockerman-managed containers participate in Unraid autostart

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -437,6 +437,80 @@
         fv3_debug_log("fv3_apply_custom_autostart: wrote " . count($newAutoStart) . " entries (" . count($sequence) . " sequenced)");
     }
 
+    // `folder.view3: <name>` label claims keyed by container name — getDockerContainers()
+    // carries no Labels, so read the same raw endpoint readInfo() uses. Returns null on a
+    // failed/partial/unnamed read so callers fail closed rather than treat label-assigned
+    // containers as unassigned (#214 class).
+    function fv3_read_container_labels(DockerClient $dockerClient, array $allContainerNames): ?array {
+        $ctLabels = [];
+        $rawCts = $dockerClient->getDockerJSON("/containers/json?all=1");
+        if (!is_array($rawCts) || count($rawCts) < count($allContainerNames)) {
+            fv3_debug_log("fv3_read_container_labels: read unavailable or incomplete");
+            return null;
+        }
+        foreach ($rawCts as $rc) {
+            $rcName = is_array($rc) ? ltrim($rc['Names'][0] ?? '', '/') : '';
+            if ($rcName === '') {
+                fv3_debug_log("fv3_read_container_labels: unnamed container in read");
+                return null;
+            }
+            $rcLabel = $rc['Labels']['folder.view3'] ?? '';
+            if (is_string($rcLabel) && $rcLabel !== '') { $ctLabels[$rcName] = $rcLabel; }
+        }
+        return $ctLabels;
+    }
+
+    // Effective membership — explicit > label > regex (issues #46/#55). Single source of
+    // truth shared by syncContainerOrder and read_membership.php (issue #61). Returns null
+    // on a corrupt persisted shape so callers fail closed instead of fataling mid-compute.
+    function fv3_compute_folder_membership(array $folders, array $allContainerNames, array $ctLabels): ?array {
+        foreach ($folders as $folder) {
+            if (!is_array($folder) || !is_array($folder['containers'] ?? [])) { return null; }
+        }
+        $folderNameSet = [];
+        foreach ($folders as $folder) {
+            if (isset($folder['name'])) { $folderNameSet[$folder['name']] = true; }
+        }
+        $folderContainers = [];
+        $folderNames = [];
+        $assignedContainers = [];
+        $explicitMembers = [];
+        foreach ($folders as $folder) {
+            $explicitMembers = array_merge($explicitMembers, $folder['containers'] ?? []);
+        }
+        $explicitAssigned = $explicitMembers;
+        foreach ($ctLabels as $ctName => $ctLabel) {
+            if (isset($folderNameSet[$ctLabel])) { $explicitAssigned[] = $ctName; }
+        }
+        foreach ($folders as $folderId => $folder) {
+            $members = $folder['containers'] ?? [];
+            // is_string + trim, not empty(): empty("0") is true in PHP, so a regex of "0" was
+            // silently dropped while docker.js applied it. The type check mirrors docker.js and
+            // keeps a non-string regex from fataling trim() (TypeError on PHP 8).
+            if (is_string($folder['regex'] ?? null) && trim($folder['regex']) !== '') {
+                $regex = '/' . str_replace('/', '\/', $folder['regex']) . '/';
+                foreach ($allContainerNames as $name) {
+                    if (@preg_match($regex, $name) && !in_array($name, $members) && !in_array($name, $explicitAssigned)) {
+                        $members[] = $name;
+                    }
+                }
+            }
+            // Explicit containers[] entries anywhere win over a label claim (issue #55)
+            foreach ($ctLabels as $ctName => $ctLabel) {
+                if ($ctLabel === ($folder['name'] ?? null) && !in_array($ctName, $members) && !in_array($ctName, $explicitMembers)) {
+                    $members[] = $ctName;
+                }
+            }
+            $members = array_values(array_filter($members, function($m) use ($allContainerNames, $assignedContainers) {
+                return in_array($m, $allContainerNames) && !in_array($m, $assignedContainers);
+            }));
+            $folderContainers["folder-$folderId"] = $members;
+            $folderNames["folder-$folderId"] = $folder['name'] ?? "folder-$folderId";
+            $assignedContainers = array_merge($assignedContainers, $members);
+        }
+        return ['containers' => $folderContainers, 'names' => $folderNames, 'assigned' => $assignedContainers];
+    }
+
     function syncContainerOrder(string $type): void {
         // Rewrites the autostart file to match what FV3 renders on screen — top-to-bottom,
         // folder members left-to-right in their editor-chosen order. Render order itself is
@@ -474,78 +548,22 @@
             return;
         }
 
-        // `folder.view3: <name>` label claims, keyed by container name. getDockerContainers()
-        // carries no Labels, so read them from the same raw endpoint readInfo() uses.
-        $ctLabels = [];
-        $rawCts = $dockerClient->getDockerJSON("/containers/json?all=1");
-        // Fail closed. A failed or partial read yields no label claims, and the order below would
-        // then write label-assigned containers back out as unassigned — the same hazard $ctListComplete
-        // guards against above, so abort rather than fall through to the permissive path.
-        if (!is_array($rawCts) || count($rawCts) < count($allContainerNames)) {
+        $ctLabels = fv3_read_container_labels($dockerClient, $allContainerNames);
+        // Fail closed: without label claims the order below would write label-assigned
+        // containers back out as unassigned — the same hazard $ctListComplete guards above.
+        if ($ctLabels === null) {
             fv3_debug_log("syncContainerOrder: label read unavailable or incomplete, aborting before write");
             return;
         }
-        foreach ($rawCts as $rc) {
-            $rcName = is_array($rc) ? ltrim($rc['Names'][0] ?? '', '/') : '';
-            if ($rcName === '') {
-                fv3_debug_log("syncContainerOrder: unnamed container in label read, aborting before write");
-                return;
-            }
-            $rcLabel = $rc['Labels']['folder.view3'] ?? '';
-            if (is_string($rcLabel) && $rcLabel !== '') { $ctLabels[$rcName] = $rcLabel; }
+        $membership = fv3_compute_folder_membership($folders, $allContainerNames, $ctLabels);
+        // Corrupt persisted shapes fail closed before the autostart write, not fatal mid-sync
+        if ($membership === null) {
+            fv3_debug_log("syncContainerOrder: folder entry with invalid containers shape, aborting before write");
+            return;
         }
-        $folderNameSet = [];
-        foreach ($folders as $folder) {
-            if (isset($folder['name'])) { $folderNameSet[$folder['name']] = true; }
-        }
-
-        // A corrupt persisted shape must abort before the autostart write, not fatal mid-sync
-        foreach ($folders as $folder) {
-            if (!is_array($folder) || !is_array($folder['containers'] ?? [])) {
-                fv3_debug_log("syncContainerOrder: folder entry with invalid containers shape, aborting before write");
-                return;
-            }
-        }
-
-        $folderContainers = [];
-        $folderNames = [];
-        $assignedContainers = [];
-        // Explicit members and label claims of any folder beat regex matches elsewhere (issue #46);
-        // explicit members alone also beat label claims elsewhere (issue #55)
-        $explicitMembers = [];
-        foreach ($folders as $folder) {
-            $explicitMembers = array_merge($explicitMembers, $folder['containers'] ?? []);
-        }
-        $explicitAssigned = $explicitMembers;
-        foreach ($ctLabels as $ctName => $ctLabel) {
-            if (isset($folderNameSet[$ctLabel])) { $explicitAssigned[] = $ctName; }
-        }
-        foreach ($folders as $folderId => $folder) {
-            $members = $folder['containers'] ?? [];
-            // is_string + trim, not empty(): empty("0") is true in PHP, so a regex of "0" was
-            // silently dropped while docker.js applied it. The type check mirrors docker.js and
-            // keeps a non-string regex from fataling trim() (TypeError on PHP 8).
-            if (is_string($folder['regex'] ?? null) && trim($folder['regex']) !== '') {
-                $regex = '/' . str_replace('/', '\/', $folder['regex']) . '/';
-                foreach ($allContainerNames as $name) {
-                    if (@preg_match($regex, $name) && !in_array($name, $members) && !in_array($name, $explicitAssigned)) {
-                        $members[] = $name;
-                    }
-                }
-            }
-            // Explicit containers[] entries anywhere win over a label claim (issue #55)
-            foreach ($ctLabels as $ctName => $ctLabel) {
-                if ($ctLabel === ($folder['name'] ?? null) && !in_array($ctName, $members) && !in_array($ctName, $explicitMembers)) {
-                    $members[] = $ctName;
-                }
-            }
-            $members = array_values(array_filter($members, function($m) use ($allContainerNames, $assignedContainers) {
-                return in_array($m, $allContainerNames) && !in_array($m, $assignedContainers);
-            }));
-            $folderContainers["folder-$folderId"] = $members;
-            $folderNames["folder-$folderId"] = $folder['name'] ?? "folder-$folderId";
-            $assignedContainers = array_merge($assignedContainers, $members);
-        }
+        $folderContainers = $membership['containers'];
+        $folderNames = $membership['names'];
+        $assignedContainers = $membership['assigned'];
 
         // Build $currentOrder. Source:
         //   - userprefs.cfg if it exists (user has drag-reordered at some point)

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -460,18 +460,30 @@
     function fv3_read_container_labels(DockerClient $dockerClient, array $allContainerNames): ?array {
         $ctLabels = [];
         $rawCts = $dockerClient->getDockerJSON("/containers/json?all=1");
-        if (!is_array($rawCts) || count($rawCts) < count($allContainerNames)) {
-            fv3_debug_log("fv3_read_container_labels: read unavailable or incomplete");
+        if (!is_array($rawCts)) {
+            fv3_debug_log("fv3_read_container_labels: read unavailable");
             return null;
         }
+        $answered = [];
         foreach ($rawCts as $rc) {
-            $rcName = is_array($rc) ? ltrim($rc['Names'][0] ?? '', '/') : '';
-            if ($rcName === '') {
+            $rcRaw = is_array($rc) ? ($rc['Names'][0] ?? '') : '';
+            // is_string first: a nested array here would fatal ltrim() on PHP 8
+            if (!is_string($rcRaw) || ltrim($rcRaw, '/') === '') {
                 fv3_debug_log("fv3_read_container_labels: unnamed container in read");
                 return null;
             }
+            $rcName = ltrim($rcRaw, '/');
+            $answered[$rcName] = true;
             $rcLabel = $rc['Labels']['folder.view3'] ?? '';
             if (is_string($rcLabel) && $rcLabel !== '') { $ctLabels[$rcName] = $rcLabel; }
+        }
+        // Identity, not cardinality: a same-size response (concurrent rename between the two
+        // Docker reads) would leave a container with no label answer and place it as unassigned.
+        foreach ($allContainerNames as $n) {
+            if (!isset($answered[$n])) {
+                fv3_debug_log("fv3_read_container_labels: '$n' missing from label read");
+                return null;
+            }
         }
         return $ctLabels;
     }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -442,11 +442,15 @@
     function fv3_read_container_names(DockerClient $dockerClient): array {
         $cts = $dockerClient->getDockerContainers();
         if (!is_array($cts)) { $cts = []; }
-        $raw = array_map(function($c) { return is_array($c) ? ($c['Name'] ?? '') : ''; }, $cts);
-        return [
-            'names' => array_values(array_filter($raw, function($n) { return $n !== ''; })),
-            'complete' => !empty($raw) && !in_array('', $raw, true),
-        ];
+        $names = [];
+        $complete = !empty($cts);
+        foreach ($cts as $c) {
+            $n = is_array($c) ? ($c['Name'] ?? '') : '';
+            // Drop non-strings too — one would reach preg_match() and fatal on PHP 8
+            if (!is_string($n) || $n === '') { $complete = false; continue; }
+            $names[] = $n;
+        }
+        return ['names' => $names, 'complete' => $complete];
     }
 
     // `folder.view3: <name>` label claims keyed by container name — getDockerContainers()
@@ -556,6 +560,14 @@
         // 'custom' = the Autostart tab's saved sequence overrides folder-derived order entirely
         if ($autostartMode === 'custom') {
             fv3_apply_custom_autostart($allContainerNames, $ctListComplete);
+            return;
+        }
+
+        // Folder-derived order needs the WHOLE list: containers missing from a partial read are
+        // skipped by the order walk and land appended at the end, silently reordering the file.
+        // Custom mode above is exempt — its order comes from the saved sequence, not this list.
+        if (!$ctListComplete) {
+            fv3_debug_log("syncContainerOrder: container list empty or incomplete, aborting before write");
             return;
         }
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -437,6 +437,18 @@
         fv3_debug_log("fv3_apply_custom_autostart: wrote " . count($newAutoStart) . " entries (" . count($sequence) . " sequenced)");
     }
 
+    // Container names from getDockerContainers(). 'complete' is false when the read is empty
+    // or any entry is unnamed — a degraded list must not drive autostart pruning (#214).
+    function fv3_read_container_names(DockerClient $dockerClient): array {
+        $cts = $dockerClient->getDockerContainers();
+        if (!is_array($cts)) { $cts = []; }
+        $raw = array_map(function($c) { return is_array($c) ? ($c['Name'] ?? '') : ''; }, $cts);
+        return [
+            'names' => array_values(array_filter($raw, function($n) { return $n !== ''; })),
+            'complete' => !empty($raw) && !in_array('', $raw, true),
+        ];
+    }
+
     // `folder.view3: <name>` label claims keyed by container name — getDockerContainers()
     // carries no Labels, so read the same raw endpoint readInfo() uses. Returns null on a
     // failed/partial/unnamed read so callers fail closed rather than treat label-assigned
@@ -465,7 +477,8 @@
     // on a corrupt persisted shape so callers fail closed instead of fataling mid-compute.
     function fv3_compute_folder_membership(array $folders, array $allContainerNames, array $ctLabels): ?array {
         foreach ($folders as $folder) {
-            if (!is_array($folder) || !is_array($folder['containers'] ?? [])) { return null; }
+            if (!is_array($folder) || !is_array($folder['containers'] ?? [])
+                || (isset($folder['name']) && !is_string($folder['name']))) { return null; }
         }
         $folderNameSet = [];
         foreach ($folders as $folder) {
@@ -535,12 +548,10 @@
         }
 
         $dockerClient = new DockerClient();
-        $cts = $dockerClient->getDockerContainers();
-        if (!is_array($cts)) { $cts = []; }
-        $ctNamesRaw = array_map(function($c) { return is_array($c) ? ($c['Name'] ?? '') : ''; }, $cts);
-        $allContainerNames = array_values(array_filter($ctNamesRaw, function($n) { return $n !== ''; }));
+        $ctNames = fv3_read_container_names($dockerClient);
+        $allContainerNames = $ctNames['names'];
         // Prune below only on a complete, fully-named container list — a degraded Docker read must not wipe autostart entries (#214)
-        $ctListComplete = !empty($ctNamesRaw) && !in_array('', $ctNamesRaw, true);
+        $ctListComplete = $ctNames['complete'];
 
         // 'custom' = the Autostart tab's saved sequence overrides folder-derived order entirely
         if ($autostartMode === 'custom') {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
@@ -10,6 +10,13 @@
         exit;
     }
     global $configDir;
+    // docker.json absent with the config dir present = no folders created yet, a real empty map.
+    // The dir itself missing means the flash config is gone (unmounted) — never answer for that.
+    if (!is_dir($configDir)) {
+        http_response_code(503);
+        echo json_encode(['error' => 'plugin config directory unavailable']);
+        exit;
+    }
     $folders = fv3_read_json_strict("$configDir/docker.json");
     if ($folders === null) {
         http_response_code(500);

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
@@ -17,10 +17,7 @@
         exit;
     }
     $dockerClient = new DockerClient();
-    $cts = $dockerClient->getDockerContainers();
-    if (!is_array($cts)) { $cts = []; }
-    $ctNamesRaw = array_map(function($c) { return is_array($c) ? ($c['Name'] ?? '') : ''; }, $cts);
-    $allContainerNames = array_values(array_filter($ctNamesRaw, function($n) { return $n !== ''; }));
+    $allContainerNames = fv3_read_container_names($dockerClient)['names'];
     $ctLabels = fv3_read_container_labels($dockerClient, $allContainerNames);
     // Fail closed — the client keeps its explicit-only fallback rather than render half a map
     if ($ctLabels === null) {

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
@@ -1,0 +1,42 @@
+<?php
+    require_once("/usr/local/emhttp/plugins/folder.view3/server/lib.php");
+    fv3_get_init();
+    header('Content-Type: application/json');
+    $type = fv3_validate_type($_GET['type'] ?? '');
+    // Labels and the autostart tab are Docker concepts — no vm consumer exists
+    if ($type !== 'docker') {
+        http_response_code(400);
+        echo json_encode(['error' => 'membership map is available for type=docker only']);
+        exit;
+    }
+    global $configDir;
+    $folders = fv3_read_json_strict("$configDir/docker.json");
+    if ($folders === null) {
+        http_response_code(500);
+        echo json_encode(['error' => 'docker.json is unreadable']);
+        exit;
+    }
+    $dockerClient = new DockerClient();
+    $cts = $dockerClient->getDockerContainers();
+    if (!is_array($cts)) { $cts = []; }
+    $ctNamesRaw = array_map(function($c) { return is_array($c) ? ($c['Name'] ?? '') : ''; }, $cts);
+    $allContainerNames = array_values(array_filter($ctNamesRaw, function($n) { return $n !== ''; }));
+    $ctLabels = fv3_read_container_labels($dockerClient, $allContainerNames);
+    // Fail closed — the client keeps its explicit-only fallback rather than render half a map
+    if ($ctLabels === null) {
+        http_response_code(503);
+        echo json_encode(['error' => 'container label read unavailable']);
+        exit;
+    }
+    $m = fv3_compute_folder_membership($folders, $allContainerNames, $ctLabels);
+    if ($m === null) {
+        http_response_code(500);
+        echo json_encode(['error' => 'folder config contains an invalid containers shape']);
+        exit;
+    }
+    $out = [];
+    foreach ($m['containers'] as $placeholder => $members) {
+        foreach ($members as $ct) { $out[$ct] = $m['names'][$placeholder]; }
+    }
+    echo json_encode(['membership' => (object)$out]);
+?>

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_membership.php
@@ -17,7 +17,15 @@
         exit;
     }
     $dockerClient = new DockerClient();
-    $allContainerNames = fv3_read_container_names($dockerClient)['names'];
+    $ctNames = fv3_read_container_names($dockerClient);
+    // An empty/partial container list must not 200 an empty map — the client would trust it
+    // and skip its explicit-only fallback. Fail closed like the label read below.
+    if (!$ctNames['complete']) {
+        http_response_code(503);
+        echo json_encode(['error' => 'container list read unavailable or incomplete']);
+        exit;
+    }
+    $allContainerNames = $ctNames['names'];
     $ctLabels = fv3_read_container_labels($dockerClient, $allContainerNames);
     // Fail closed — the client keeps its explicit-only fallback rather than render half a map
     if ($ctLabels === null) {


### PR DESCRIPTION
The Autostart tab's Folder column resolved a container's folder with an explicit-`containers[]`-only scan (`fv3AsFolderOf`), so a container that belongs to a folder via a `folder.view3` label claim or a folder regex showed an empty badge — while sitting inside that folder's block of the very sequence the tab displays, since the ordering comes from `syncContainerOrder()`, which honours label and regex membership (#46/#54/#55).

Rather than adding a fourth client-side copy of the membership rules, the calculation becomes the server's single source of truth:

- `lib.php` — the label read and the effective-membership computation (explicit > label > regex) move out of `syncContainerOrder()` into `fv3_read_container_labels()` and `fv3_compute_folder_membership()`. The sync consumes them unchanged, keeping its fail-closed abort when the label read is unavailable, partial, or contains an unnamed container.
- `server/read_membership.php` (new, GET, docker-only) — returns the effective `container → folder name` map. Fails closed: 400 for non-docker types, 500 on unreadable folder config, 503 when the label read is degraded — never a half-computed map.
- `scripts/folderview3.js` — the tab fetches the map alongside its existing reads (`.catch(() => null)` so a failure can't reject the `Promise.all`), and `fv3AsFolderOf()` answers from it, falling back to the old explicit-only scan when the map is unavailable. Lookups are `hasOwnProperty`-guarded so Docker-legal names like `constructor` can't walk the prototype chain.

Verified on Unraid with the #55 fixture recipe (throwaway folders/containers, byte-identical restore afterwards): the refactored sync produced **byte-identical** autostart output to the pre-refactor code in both the contested (explicit-beats-label) and label-only scenarios, and the endpoint map resolved the contested container to its explicit folder and the label-only container to its claiming folder.

Out of scope: `orderFolderIds()` on the same page still sorts the folder list by explicit members only — cosmetic, noted in #61 as optional.

Closes #61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-provided Docker container-to-folder membership data.
  * Autostart folder badges now recognize label- and regex-based membership.
  * Added clearer error responses when membership data cannot be retrieved or validated.

* **Bug Fixes**
  * Improved autostart membership loading with parallel data retrieval.
  * Added reliable fallback behavior when server data is unavailable.
  * Preserved safe handling of incomplete container information and invalid folder configurations.
  * Prevented folder synchronization when Docker data or folder settings are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->