### PR TITLE
ci: add an on-demand test build and pin the shared release workflow to its current commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: chodeus/chodeus-ops
-          ref: 5c3687a2f488fdd69f89c36c98e790203e603109 # main
+          ref: ab24506df084c71a4ca0f04b29ec96315cbbe42f # main
           path: .ops
           sparse-checkout: scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   release:
-    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-release.yml@5c3687a2f488fdd69f89c36c98e790203e603109 # main
+    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-release.yml@ab24506df084c71a4ca0f04b29ec96315cbbe42f # main
     with:
       plg_file: folder.view3.plg
       stable_branch: main

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,30 @@
+# On-demand test build; the run summary shows the install URL. Inputs: chodeus-ops unraid-plugin-test-build.yml.
+
+name: Test build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional YYYY.MM.DD[.N]. Empty = yesterday + .9<run>, which installs over the current release and is replaced by the next one.'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+# One rolling pre-release per repo; two runs at once would race to replace it.
+concurrency:
+  group: plg-test-build
+  cancel-in-progress: false
+
+jobs:
+  test-build:
+    # The called workflow can use at most what this job grants: it needs to replace the pre-release and its tag.
+    permissions:
+      contents: write
+    # Pin to a reviewed chodeus-ops commit.
+    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-test-build.yml@ab24506df084c71a4ca0f04b29ec96315cbbe42f # main
+    with:
+      plg_file: folder.view3.plg
+      version: ${{ inputs.version || '' }}


### PR DESCRIPTION
Adds a manual **Test build** workflow and moves the shared release workflow to its current commit.

Run the test build from the Actions tab on the branch to test. It builds the package with the same script the release uses, publishes it as one rolling pre-release named `test`, verifies the manifest and package checksum from the release URL, and prints the install URL in the run summary. Paste that URL into Plugins > Install Plugin. The default version is yesterday's date plus `.9` and the run number, so it installs over the current release and is replaced by the next real one. Nothing on `beta` moves: no branch push, no `v` tag, and `pluginURL` stays on `beta`.

The release workflow and its scripts move from `5c3687a` to `ab24506`, the same chodeus-ops commit the caller pins. That commit also adds `@coderabbitai ignore` to the generated release PR body, so CodeRabbit stops spending review attempts on the changelog PR each time it is rebuilt.

The caller is the chodeus-ops template pinned to the reviewed commit; the reusable itself was reviewed in chodeus-ops #16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered workflow for building the test package, with optional version selection and controlled release tagging.

- **Chores**
  - Updated automated build and release processes to use newer, pinned workflow revisions.
  - Improved workflow permissions and run coordination for safer, more consistent package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->