### PR TITLE
fix: resolve container update status per container, not per image

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
@@ -39,6 +39,9 @@ const createFolders = async () => {
         const containersInfo = fv3SafeParse(prom[2], {});
         let order = Object.values(fv3SafeParse(prom[3], {}));
 
+        // Must run before the render loop — every update surface reads ct.info.State.Updated
+        fv3ApplyUpdateStatuses(containersInfo, prom[4]);
+
         fv3ResolveRenamedContainers(folders, containersInfo, 'docker');
         Object.values(folders).forEach(f => fv3ApplyDefaults(f));
 
@@ -136,22 +139,6 @@ const createFolders = async () => {
         }}));
 
         globalFolders.docker = foldersDone;
-
-        fv3CheckUpdates().then(statuses => {
-            if (!statuses || !Object.keys(statuses).length) return;
-            fv3Debug('dashboard', 'API update statuses received:', statuses);
-            for (const [folderId, folder] of Object.entries(globalFolders.docker || {})) {
-                if (!folder.containers) continue;
-                // containers stays an array on the dashboard (never replaced like docker.js does)
-                const memberNames = Array.isArray(folder.containers) ? folder.containers : Object.keys(folder.containers);
-                for (const containerName of memberNames) {
-                    if (statuses[containerName] === 'UPDATE_AVAILABLE') {
-                        folder.status.upToDate = false;
-                        break;
-                    }
-                }
-            }
-        });
 
         fv3SyncOrganizer(globalFolders.docker || {});
 
@@ -1842,7 +1829,8 @@ window.loadlist = (x) => {
             $.get('/plugins/folder.view3/server/read.php?type=docker').fail((jq) => { jq.fv3Bannered = true; fv3ShowBanner('Could not load Docker folder data. Try refreshing the page.', 'error'); }).promise(),
             $.get('/plugins/folder.view3/server/read_order.php?type=docker').promise(),
             $.get('/plugins/folder.view3/server/read_info.php?type=docker').fail((jq) => { jq.fv3Bannered = true; fv3ShowBanner('Could not load container details. Try refreshing the page.', 'error'); }).promise(),
-            $.get('/plugins/folder.view3/server/read_unraid_order.php?type=docker').promise()
+            $.get('/plugins/folder.view3/server/read_unraid_order.php?type=docker').promise(),
+            fv3CheckUpdates()
         ];
     }
 

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/docker.js
@@ -26,6 +26,9 @@ const createFolders = async () => {
     const containersInfo = fv3SafeParse(prom[2], {});
     let order = Object.values(fv3SafeParse(prom[3], {}));
 
+    // Must run before the render loop — every update surface reads ct.info.State.Updated
+    fv3ApplyUpdateStatuses(containersInfo, prom[4]);
+
     fv3ResolveRenamedContainers(folders, containersInfo, 'docker');
     Object.values(folders).forEach(f => fv3ApplyDefaults(f));
 
@@ -220,29 +223,6 @@ const createFolders = async () => {
     fv3Debug('createFolders', 'Assigned foldersDone to globalFolders:', {...globalFolders});
 
     requestAnimationFrame(() => fv3SyncPreviewHeights('docker_listview_mode'));
-
-    fv3CheckUpdates().then(statuses => {
-        if (!statuses || !Object.keys(statuses).length) return;
-        fv3Debug('createFolders', 'API update statuses received:', statuses);
-        for (const [folderId, folder] of Object.entries(globalFolders)) {
-            let folderHasUpdate = false;
-            if (!folder.containers) continue;
-            for (const containerName of Object.keys(folder.containers)) {
-                if (statuses[containerName] === 'UPDATE_AVAILABLE') {
-                    folderHasUpdate = true;
-                    break;
-                }
-            }
-            if (folderHasUpdate) {
-                const $badge = $(`tr.folder-id-${folderId} .folder-update-text`);
-                if ($badge.length && !$badge.hasClass('orange-text')) {
-                    $badge.removeClass('green-text').addClass('orange-text')
-                        .html(`<i class="fa fa-flash fa-fw"></i> ${$.i18n('update-ready')}`);
-                    fv3Debug('createFolders', `Folder ${folderId} has update available`);
-                }
-            }
-        }
-    });
 
     fv3SyncOrganizer(globalFolders);
 
@@ -1188,10 +1168,11 @@ window.loadlist = () => {
             $.get('/plugins/folder.view3/server/read.php?type=docker').fail(() => fv3ShowBanner('Could not load folder data. Try refreshing the page.', 'error')).promise(),
             $.get('/plugins/folder.view3/server/read_order.php?type=docker').promise(),
             $.get('/plugins/folder.view3/server/read_info.php?type=docker').fail(() => fv3ShowBanner('Could not load container details. Try refreshing the page.', 'error')).promise(),
-            $.get('/plugins/folder.view3/server/read_unraid_order.php?type=docker').promise()
+            $.get('/plugins/folder.view3/server/read_unraid_order.php?type=docker').promise(),
+            fv3CheckUpdates()
         ];
         Promise.all(folderReq).finally(() => { fv3FolderReqPending = false; });
-        fv3Debug('Patched loadlist', 'folderReq initialized with 4 promises.');
+        fv3Debug('Patched loadlist', 'folderReq initialized with 5 promises.');
     } else {
         fv3Debug('Patched loadlist', 'Skipping — requests already pending.');
     }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -1400,13 +1400,14 @@ window.fv3ApiAvailable = null;
 window.fv3CpuCores = null;
 window.fv3UnraidTheme = null;
 
-window.fv3DetectApi = async () => {
+window.fv3DetectApi = async (signal) => {
     if (fv3ApiAvailable !== null) return fv3ApiAvailable;
     try {
         const resp = await fetch('/graphql', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': typeof csrf_token !== 'undefined' ? csrf_token : '' },
             credentials: 'same-origin',
+            signal: signal,
             body: JSON.stringify({ query: '{ info { os { release } cpu { cores } } }' })
         });
         if (resp.ok) {
@@ -1425,17 +1426,20 @@ window.fv3DetectApi = async () => {
             fv3ApiAvailable = false;
         }
     } catch (e) {
+        // an aborted probe proves nothing — leave fv3ApiAvailable unset so the next call retries
+        if (e && e.name === 'AbortError') return null;
         fv3ApiAvailable = false;
     }
     if (!fv3ApiAvailable) fv3Debug('API', 'GraphQL not available, using PHP fallback');
     return fv3ApiAvailable;
 };
 
-window.fv3GraphQL = async (query, variables) => {
+window.fv3GraphQL = async (query, variables, signal) => {
     const resp = await fetch('/graphql', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': typeof csrf_token !== 'undefined' ? csrf_token : '' },
         credentials: 'same-origin',
+        signal: signal,
         body: JSON.stringify(variables ? { query: query, variables: variables } : { query: query })
     });
     if (!resp.ok) throw new Error('GraphQL HTTP ' + resp.status);
@@ -1528,11 +1532,12 @@ window.fv3VmAction = (action, uuid) => {
 // Neither fv3DetectApi nor fv3GraphQL has a timeout, so a hung /graphql would stall the
 // render this feeds. Cap it and fall through to the PHP value instead.
 window.fv3CheckUpdates = async (timeoutMs = 4000) => {
+    var ctl = typeof AbortController !== 'undefined' ? new AbortController() : null;
     var timer;
-    var bail = new Promise(resolve => { timer = setTimeout(() => resolve('__fv3_timeout'), timeoutMs); });
+    var bail = new Promise(resolve => { timer = setTimeout(() => { if (ctl) ctl.abort(); resolve('__fv3_timeout'); }, timeoutMs); });
     var work = (async () => {
-        if (!await fv3DetectApi()) return {};
-        var data = await fv3GraphQL('{ docker { containerUpdateStatuses { name updateStatus } } }');
+        if (!await fv3DetectApi(ctl && ctl.signal)) return {};
+        var data = await fv3GraphQL('{ docker { containerUpdateStatuses { name updateStatus } } }', undefined, ctl && ctl.signal);
         var statuses = data && data.docker && data.docker.containerUpdateStatuses;
         if (!statuses) return {};
         var result = {};

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -1525,22 +1525,57 @@ window.fv3VmAction = (action, uuid) => {
     return phpFallback();
 };
 
-window.fv3CheckUpdates = async () => {
-    if (!await fv3DetectApi()) return {};
-    try {
+// Neither fv3DetectApi nor fv3GraphQL has a timeout, so a hung /graphql would stall the
+// render this feeds. Cap it and fall through to the PHP value instead.
+window.fv3CheckUpdates = async (timeoutMs = 4000) => {
+    var timer;
+    var bail = new Promise(resolve => { timer = setTimeout(() => resolve('__fv3_timeout'), timeoutMs); });
+    var work = (async () => {
+        if (!await fv3DetectApi()) return {};
         var data = await fv3GraphQL('{ docker { containerUpdateStatuses { name updateStatus } } }');
         var statuses = data && data.docker && data.docker.containerUpdateStatuses;
         if (!statuses) return {};
         var result = {};
         for (var i = 0; i < statuses.length; i++) {
-            result[statuses[i].name] = statuses[i].updateStatus;
+            // API returns docker-style names ('/plex') — strip the slash to match FV3 names
+            result[(statuses[i].name || '').replace(/^\//, '')] = statuses[i].updateStatus;
         }
         fv3Debug('API', 'Update check complete:', Object.keys(result).length, 'containers');
         return result;
+    })();
+    // the loser of the race is still live — swallow its result so a late reject isn't unhandled
+    work.catch(() => {});
+    try {
+        var won = await Promise.race([work, bail]);
+        if (won === '__fv3_timeout') { fv3DebugWarn('API', 'Update check timed out after', timeoutMs, 'ms — using PHP status'); return {}; }
+        return won;
     } catch (e) {
         fv3Debug('API', 'Update check failed:', e.message);
         return {};
+    } finally {
+        clearTimeout(timer);
     }
+};
+
+// API is authoritative where it has an opinion; UNKNOWN/absent leaves the PHP value
+// (lib.php fv3_container_update_status) intact so non-API installs keep working.
+window.fv3ApplyUpdateStatuses = (containersInfo, statuses) => {
+    if (!containersInfo || !statuses || !Object.keys(statuses).length) return 0;
+    var map = { UPDATE_AVAILABLE: false, REBUILD_READY: false, UP_TO_DATE: true };
+    var applied = 0;
+    Object.keys(containersInfo).forEach(name => {
+        var st = statuses[name];
+        if (!Object.prototype.hasOwnProperty.call(map, st)) return;
+        var ct = containersInfo[name];
+        if (!ct || !ct.info || !ct.info.State) return;
+        if (ct.info.State.Updated !== map[st]) {
+            fv3Debug('API', 'Update status override:', name, ct.info.State.Updated, '->', map[st], `(${st})`);
+        }
+        ct.info.State.Updated = map[st];
+        applied++;
+    });
+    fv3Debug('API', 'Applied API update status to', applied, 'containers');
+    return applied;
 };
 
 // Organizer sync

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1566,6 +1566,25 @@
         return $DockerUpdate->getUpdateStatus($ct['info']['Config']['Image']);
     }
 
+    // /containers/json is ~5ms; the per-container inspect work readInfo() does is not.
+    // Lets the read_info cache miss on a state change instead of only on elapsed time.
+    function fv3_docker_state_fingerprint(): string {
+        try {
+            $cts = (new DockerClient())->getDockerJSON("/containers/json?all=1");
+            if (!is_array($cts)) return '';
+            $parts = [];
+            foreach ($cts as $c) {
+                $parts[] = ($c['Id'] ?? '') . ':' . ($c['State'] ?? '') . ':' . ($c['ImageID'] ?? '');
+            }
+            sort($parts);
+            $parts[] = 'autostart:' . (@filemtime(fv3_autostart_file()) ?: 0);
+            return md5(implode('|', $parts));
+        } catch (Throwable $e) {
+            fv3_debug_log("fv3_docker_state_fingerprint failed: " . $e->getMessage());
+            return '';
+        }
+    }
+
     function readInfo(string $type): array {
         fv3_debug_log("readInfo called for type: $type");
         $info = [];

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1574,7 +1574,9 @@
             if (!is_array($cts)) return '';
             $parts = [];
             foreach ($cts as $c) {
-                $parts[] = ($c['Id'] ?? '') . ':' . ($c['State'] ?? '') . ':' . ($c['ImageID'] ?? '');
+                // name included: readInfo() keys its payload by it, and a rename changes nothing else here
+                $parts[] = ($c['Id'] ?? '') . ':' . ($c['State'] ?? '') . ':' . ($c['ImageID'] ?? '')
+                    . ':' . ltrim($c['Names'][0] ?? '', '/');
             }
             sort($parts);
             $parts[] = 'autostart:' . (@filemtime(fv3_autostart_file()) ?: 0);

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1555,6 +1555,17 @@
         fv3_atomic_write($path, '{}');
     }
 
+    // Mirrors DockerContainers.php:82 — ':???' net-ref wins, then Unraid's per-container cache.
+    // Only 'updated' comes from that cache; WebUi/Shell stay live here (the cache holds unresolved [IP]/[PORT:n]).
+    function fv3_container_update_status(array $ct, string $name, array $cache, DockerUpdate $DockerUpdate): ?bool {
+        if (substr($ct['HostConfig']['NetworkMode'] ?? '', -4) === ':???') return false;
+        $entry = $cache[$name] ?? null;
+        if (is_array($entry) && array_key_exists('updated', $entry)) {
+            return $entry['updated'] === 'true' ? true : ($entry['updated'] === 'false' ? false : null);
+        }
+        return $DockerUpdate->getUpdateStatus($ct['info']['Config']['Image']);
+    }
+
     function readInfo(string $type): array {
         fv3_debug_log("readInfo called for type: $type");
         $info = [];
@@ -1574,6 +1585,8 @@
             $autoStartFile = $dockerManPaths['autostart-file'] ?? "/var/lib/docker/unraid-autostart";
             $autoStartLines = @file($autoStartFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
             $autoStart = array_map('var_split', $autoStartLines);
+            $dockerInfoCache = DockerUtil::loadJSON($dockerManPaths['webui-info'] ?? "/usr/local/emhttp/state/plugins/dynamix.docker.manager/docker.json");
+            if (!is_array($dockerInfoCache)) $dockerInfoCache = [];
 
             // Prune stale autostart entries only on a complete, fully-named container list.
             // A failed/partial Docker read (empty $cts, or any entry without a name) must NOT prune, or a transient blip wipes/curtails the file.
@@ -1624,7 +1637,7 @@
 
                 $ct['info']['State']['Autostart'] = in_array($containerName, $autoStart);
                 $ct['info']['Config']['Image'] = DockerUtil::ensureImageTag($ct['info']['Config']['Image']);
-                $ct['info']['State']['Updated'] = $DockerUpdate->getUpdateStatus($ct['info']['Config']['Image']);
+                $ct['info']['State']['Updated'] = fv3_container_update_status($ct, $containerName, $dockerInfoCache, $DockerUpdate);
                 $ct['info']['State']['manager'] = $ct['Labels']['net.unraid.docker.managed'] ?? false;
                 $ct['shortId'] = substr(str_replace('sha256:', '', $ct['Id']), 0, 12);
                 $ct['shortImageId'] = substr(str_replace('sha256:', '', $ct['ImageID']), 0, 12);

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/lib.php
@@ -1566,27 +1566,6 @@
         return $DockerUpdate->getUpdateStatus($ct['info']['Config']['Image']);
     }
 
-    // /containers/json is ~5ms; the per-container inspect work readInfo() does is not.
-    // Lets the read_info cache miss on a state change instead of only on elapsed time.
-    function fv3_docker_state_fingerprint(): string {
-        try {
-            $cts = (new DockerClient())->getDockerJSON("/containers/json?all=1");
-            if (!is_array($cts)) return '';
-            $parts = [];
-            foreach ($cts as $c) {
-                // name included: readInfo() keys its payload by it, and a rename changes nothing else here
-                $parts[] = ($c['Id'] ?? '') . ':' . ($c['State'] ?? '') . ':' . ($c['ImageID'] ?? '')
-                    . ':' . ltrim($c['Names'][0] ?? '', '/');
-            }
-            sort($parts);
-            $parts[] = 'autostart:' . (@filemtime(fv3_autostart_file()) ?: 0);
-            return md5(implode('|', $parts));
-        } catch (Throwable $e) {
-            fv3_debug_log("fv3_docker_state_fingerprint failed: " . $e->getMessage());
-            return '';
-        }
-    }
-
     function readInfo(string $type): array {
         fv3_debug_log("readInfo called for type: $type");
         $info = [];

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
@@ -6,9 +6,13 @@
 
     $cacheTtl = 5;
     $cacheFile = "/tmp/fv3_read_info_{$type}.json";
+    $fpFile = "{$cacheFile}.fp";
+    // '' when unavailable (VMs, or a failed Docker read) — then elapsed time alone gates the cache
+    $fingerprint = $type === 'docker' ? fv3_docker_state_fingerprint() : '';
     clearstatcache(true, $cacheFile);
     // size guard: a 0-byte or '[]' cache file is a poisoned entry, never a real container list
-    if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl && filesize($cacheFile) > 2) {
+    if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl && filesize($cacheFile) > 2
+        && (@file_get_contents($fpFile) ?: '') === $fingerprint) {
         readfile($cacheFile);
         exit;
     }
@@ -20,6 +24,8 @@
     if ($json !== false && !empty($data)) {
         @file_put_contents($cacheFile, $json, LOCK_EX);
         @chmod($cacheFile, 0600);
+        @file_put_contents($fpFile, $fingerprint, LOCK_EX);
+        @chmod($fpFile, 0600);
     } else {
         fv3_debug_log("read_info: not caching (encode=" . ($json === false ? 'FAILED' : 'ok') . ", entries=" . count((array)$data) . ")");
     }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
@@ -6,15 +6,22 @@
 
     $cacheTtl = 5;
     $cacheFile = "/tmp/fv3_read_info_{$type}.json";
-    $fpFile = "{$cacheFile}.fp";
     // '' when unavailable (VMs, or a failed Docker read) — then elapsed time alone gates the cache
     $fingerprint = $type === 'docker' ? fv3_docker_state_fingerprint() : '';
     clearstatcache(true, $cacheFile);
-    // size guard: a 0-byte or '[]' cache file is a poisoned entry, never a real container list
-    if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl && filesize($cacheFile) > 2
-        && (@file_get_contents($fpFile) ?: '') === $fingerprint) {
-        readfile($cacheFile);
-        exit;
+    // One record — fingerprint line then payload — so a concurrent writer can never pair one
+    // request's fingerprint with another's payload. Size check rejects a poisoned/empty entry.
+    $fh = @fopen($cacheFile, 'rb');
+    if ($fh) {
+        $fresh = (time() - (@filemtime($cacheFile) ?: 0)) < $cacheTtl;
+        $stored = rtrim((string)fgets($fh), "\n");
+        $stat = fstat($fh);
+        if ($fresh && $stored === $fingerprint && ($stat['size'] - ftell($fh)) > 2) {
+            fpassthru($fh);
+            fclose($fh);
+            exit;
+        }
+        fclose($fh);
     }
 
     $data = readInfo($type);
@@ -22,10 +29,7 @@
     // Never cache an encode failure (invalid UTF-8 in a name/label) or an empty read (Docker blip):
     // 5s of an empty payload renders every folder with no containers.
     if ($json !== false && !empty($data)) {
-        @file_put_contents($cacheFile, $json, LOCK_EX);
-        @chmod($cacheFile, 0600);
-        @file_put_contents($fpFile, $fingerprint, LOCK_EX);
-        @chmod($fpFile, 0600);
+        fv3_atomic_write($cacheFile, $fingerprint . "\n" . $json, 0600);
     } else {
         fv3_debug_log("read_info: not caching (encode=" . ($json === false ? 'FAILED' : 'ok') . ", entries=" . count((array)$data) . ")");
     }

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
@@ -4,33 +4,13 @@
     header('Content-Type: application/json');
     $type = fv3_validate_type($_GET['type'] ?? '');
 
-    $cacheTtl = 5;
-    $cacheFile = "/tmp/fv3_read_info_{$type}.json";
-    // '' when unavailable (VMs, or a failed Docker read) — then elapsed time alone gates the cache
-    $fingerprint = $type === 'docker' ? fv3_docker_state_fingerprint() : '';
-    // One record — fingerprint line then payload — so a concurrent writer can never pair one
-    // request's fingerprint with another's payload. Every field comes from the open handle, never
-    // the path: fv3_atomic_write() renames, so a path stat can describe a different file than $fh.
-    $fh = @fopen($cacheFile, 'rb');
-    if ($fh) {
-        $stat = fstat($fh);
-        $stored = rtrim((string)fgets($fh), "\n");
-        if ((time() - $stat['mtime']) < $cacheTtl && $stored === $fingerprint && ($stat['size'] - ftell($fh)) > 2) {
-            fpassthru($fh);
-            fclose($fh);
-            exit;
-        }
-        fclose($fh);
+    // Deliberately uncached: readInfo() costs ~17ms, and any cache has to mirror every input it
+    // reads (container state, names, autostart, update status, templates) or it serves stale data.
+    $json = json_encode(readInfo($type));
+    if ($json === false) {
+        // invalid UTF-8 in a container name or label — send an empty map rather than a blank body
+        fv3_debug_log("read_info: json_encode failed for type $type");
+        $json = '{}';
     }
-
-    $data = readInfo($type);
-    $json = json_encode($data);
-    // Never cache an encode failure (invalid UTF-8 in a name/label) or an empty read (Docker blip):
-    // 5s of an empty payload renders every folder with no containers.
-    if ($json !== false && !empty($data)) {
-        fv3_atomic_write($cacheFile, $fingerprint . "\n" . $json, 0600);
-    } else {
-        fv3_debug_log("read_info: not caching (encode=" . ($json === false ? 'FAILED' : 'ok') . ", entries=" . count((array)$data) . ")");
-    }
-    echo $json === false ? '{}' : $json;
+    echo $json;
 ?>

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
@@ -8,15 +8,14 @@
     $cacheFile = "/tmp/fv3_read_info_{$type}.json";
     // '' when unavailable (VMs, or a failed Docker read) — then elapsed time alone gates the cache
     $fingerprint = $type === 'docker' ? fv3_docker_state_fingerprint() : '';
-    clearstatcache(true, $cacheFile);
     // One record — fingerprint line then payload — so a concurrent writer can never pair one
-    // request's fingerprint with another's payload. Size check rejects a poisoned/empty entry.
+    // request's fingerprint with another's payload. Every field comes from the open handle, never
+    // the path: fv3_atomic_write() renames, so a path stat can describe a different file than $fh.
     $fh = @fopen($cacheFile, 'rb');
     if ($fh) {
-        $fresh = (time() - (@filemtime($cacheFile) ?: 0)) < $cacheTtl;
-        $stored = rtrim((string)fgets($fh), "\n");
         $stat = fstat($fh);
-        if ($fresh && $stored === $fingerprint && ($stat['size'] - ftell($fh)) > 2) {
+        $stored = rtrim((string)fgets($fh), "\n");
+        if ((time() - $stat['mtime']) < $cacheTtl && $stored === $fingerprint && ($stat['size'] - ftell($fh)) > 2) {
             fpassthru($fh);
             fclose($fh);
             exit;

--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/server/read_info.php
@@ -6,13 +6,22 @@
 
     $cacheTtl = 5;
     $cacheFile = "/tmp/fv3_read_info_{$type}.json";
-    if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl) {
+    clearstatcache(true, $cacheFile);
+    // size guard: a 0-byte or '[]' cache file is a poisoned entry, never a real container list
+    if (file_exists($cacheFile) && (time() - filemtime($cacheFile)) < $cacheTtl && filesize($cacheFile) > 2) {
         readfile($cacheFile);
         exit;
     }
 
-    $json = json_encode(readInfo($type));
-    @file_put_contents($cacheFile, $json, LOCK_EX);
-    @chmod($cacheFile, 0600);
-    echo $json;
+    $data = readInfo($type);
+    $json = json_encode($data);
+    // Never cache an encode failure (invalid UTF-8 in a name/label) or an empty read (Docker blip):
+    // 5s of an empty payload renders every folder with no containers.
+    if ($json !== false && !empty($data)) {
+        @file_put_contents($cacheFile, $json, LOCK_EX);
+        @chmod($cacheFile, 0600);
+    } else {
+        fv3_debug_log("read_info: not caching (encode=" . ($json === false ? 'FAILED' : 'ok') . ", entries=" . count((array)$data) . ")");
+    }
+    echo $json === false ? '{}' : $json;
 ?>


### PR DESCRIPTION
## The bug

`radarrmusic` showed **update ready** on its own container row, but its title in the folder preview stayed plain. Two surfaces reading two different sources.

`readInfo()` derived `State.Updated` from `getUpdateStatus($image)`, which reads `unraid-update-status.json` — keyed by **image tag**. Three containers here share `ghcr.io/hotio/radarr:nightly`; once `radarr` and `radarr4k` pulled the new image that file read `local == remote` and reported the whole tag up to date. `radarrmusic` was still running the older image ID and the per-image check had no way to express that.

Unraid's own row never used that file. It reads a per-container cache (`state/plugins/dynamix.docker.manager/docker.json`), which is why the row was right and the preview was not.

## Changes

**Update status per container, not per image.** `fv3_container_update_status()` reads the same per-container cache `DockerContainers.php` uses, mirrors its `:???` rebuild case, and falls back to the old per-image call when a container has no cache entry. All four consumers of `State.Updated` — preview title, tooltip, folder badge, and the apply-update target list — read one corrected value, so no consumer needed editing.

**GraphQL feeds the same value.** The API check now resolves alongside the other folder requests and writes `State.Updated` directly instead of repainting only the folder badge after render. It is capped by a timeout, cancels its request via `AbortController` when that timeout wins, and only overrides where the API has an opinion — so installs without the API stay on the PHP path. `fv3DetectApi()` returns `null` on `AbortError` rather than caching `false`, so an aborted probe does not strand the page on the PHP path until reload.

**The `read_info` cache is gone.** It was originally kept and given a state fingerprint, but measurement did not support it (7.3.2, 44 containers):

| variant | ms/req |
|---|---|
| cache miss | 58 |
| cache hit | 36 |
| no cache | 54 |

`readInfo()` is ~17 ms; a hit saved 18 ms, and a **miss was 4 ms slower than no cache at all**. A page fires one request, so a miss is the common case, and the dashboard's two requests use different types so cannot share an entry. Unraid only re-polls while Docker is busy, at 5000 ms against a 5000 ms TTL, and not at all when the tab is hidden.

The deeper problem was that a fingerprint can only approximate "has anything `readInfo()` reads changed". It covered id, state, image and name and still missed `docker.json` — flipping a container's update status stayed invisible for the whole TTL, which is the same staleness this PR exists to remove. Removing the cache deletes that class outright. The `json_encode()` guard stays: an encode failure answers `{}` rather than a blank body.

## Verification

Unraid 7.3.2, 44 containers, each assertion paired with a control:

- **Property check, immune to state drift:** for all 44 containers, `State.Updated` equals what `DockerContainers.php:82` would render — 0 mismatches, spread 32 true / 11 false / 1 null. Controls confirm the mapping is read, not guessed.
- Compose and 3rd-party containers built on a genuinely out-of-date image stay non-updatable, while a `dockerman` container **on the same image** is updatable — the guard from 9291096 still holds.
- Rename, start/stop and `docker.json` update-status changes are all reflected immediately; each previously stale for up to 5 s.
- No cache artefacts created; `type=docker` and `type=vm` both return valid JSON.
- API forced unavailable: preview still correct from the PHP path alone.
- Timeout path: abort reaches the in-flight request, returns `{}`, and leaves `fv3ApiAvailable` unset.

## Note for reviewers

WebUI URLs deliberately keep resolving live rather than reading that same per-container cache: for 10 containers the cache holds unresolved `[IP]`/`[PORT:n]` templates, so adopting it there would regress them. The rule is per-field, and there is a comment at the function recording why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Docker folder and container update indicators now appear correctly as folders load.
  - Update checks are more reliable, with timeouts, cancellation of stalled requests, and improved retry behavior.
  - Container statuses now remain accurate when live status data is unavailable or incomplete.
  - Docker names and update states are handled consistently across supported status sources.

- **Performance**
  - Dashboard and Docker update information load in parallel, reducing delays before status indicators are displayed.
  - Folder data now uses current results instead of previously cached responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->