### PR TITLE
Test build per pull request via the test-build label

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,27 @@
+# Caller for one test build of a pull request per press of the test-build label; replace PLUGIN.plg below. Needs
+# "PR publish", "PR cleanup" and a repo label named test-build. Mechanics: .github/workflows/unraid-plugin-pr-build.yml.
+
+name: PR build
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    # Only the label press builds; the pull request's own build script runs with a read-only token.
+    if: github.event.label.name == 'test-build'
+    # Pin to a reviewed chodeus-ops commit.
+    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-pr-build.yml@2ef08fcd646d269404bc80d30c249ecac949a724 # main
+    with:
+      plg_file: folder.view3.plg
+      pr_number: ${{ github.event.pull_request.number }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      base_branch: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,21 @@
+# Caller that removes a pull request's test builds when it closes. Checks out nothing.
+# Mechanics: .github/workflows/unraid-plugin-pr-cleanup.yml.
+
+name: PR cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    permissions:
+      contents: write
+      pull-requests: write
+    # Pin to a reviewed chodeus-ops commit.
+    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-pr-cleanup.yml@2ef08fcd646d269404bc80d30c249ecac949a724 # main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -1,0 +1,33 @@
+# Caller that turns a finished "PR build" into a pr-<number>-<version> pre-release, comments the install URL and
+# takes the test-build label off; runs default-branch code only. Mechanics: .github/workflows/unraid-plugin-pr-publish.yml.
+
+name: PR publish
+
+on:
+  workflow_run:
+    workflows: ["PR build"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-publish-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    # The called workflow can use at most what this job grants: releases, the comment, the artifact.
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    # Pin to a reviewed chodeus-ops commit.
+    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-pr-publish.yml@2ef08fcd646d269404bc80d30c249ecac949a724 # main
+    with:
+      run_id: ${{ github.event.workflow_run.id }}
+      head_owner: ${{ github.event.workflow_run.head_repository.owner.login }}
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      plg_file: folder.view3.plg

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Optional YYYY.MM.DD[.N]. Empty = yesterday + .9<UTC build time>, which installs over the current release and is superseded by the next one.'
+        description: 'Optional. Empty = the branch release + .0<UTC build time>, which installs over the current release and is superseded by the next one.'
         type: string
         default: ''
 
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     # Pin to a reviewed chodeus-ops commit.
-    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-test-build.yml@c7105215e46ad278814e8e89ba8fd50813567039 # main
+    uses: chodeus/chodeus-ops/.github/workflows/unraid-plugin-test-build.yml@2ef08fcd646d269404bc80d30c249ecac949a724 # main
     with:
       plg_file: folder.view3.plg
       version: ${{ inputs.version || '' }}


### PR DESCRIPTION
Callers for the chodeus-ops pull request test builds (chodeus/chodeus-ops#18): adding the `test-build` label to a pull request gives one build, a `pr-<number>-<version>` pre-release, one comment with the install URL, and the label comes off again. Publish and cleanup fire from main; the same files go to beta in a second PR because pull requests target beta. Pinned to the chodeus-ops #18 merge commit. The manual test build moves to the same commit, which brings #18's fixes to it: the version sits just above the branch's release, and the previous test build goes only after the new one is verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull request build validation for builds marked for testing.
  * Added cleanup automation when pull requests are closed.
  * Added automated publishing after successful pull request builds.
  * Added safeguards for workflow permissions, concurrent runs, and reproducible execution.
  * Updated the test-build workflow configuration and improved its version input guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
